### PR TITLE
Configure Testem

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mocha_reporter": "spec"
   },
   "scripts": {
+    "start": "testem",
     "test": "mocha -u mocha-gwt -R $npm_package_config_mocha_reporter --compilers coffee:coffee-script --recursive test/helper.coffee test/",
     "test:debug": "npm test -- --debug-brk",
     "preversion": "git pull --rebase && npm test",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "grunt": "~0.4.2",
     "mocha": "^2.3.1",
     "mocha-gwt": "^0.2.0",
     "testem": "~0.6.15"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "http://testdouble.com"
   },
   "scripts": {
-    "test": "mocha --ui mocha-gwt --recursive --require coffee-script --compilers coffee:coffee-script/register 'test/helper.coffee' 'test/'",
+    "test": "mocha --ui mocha-gwt --recursive --require coffee-script --compilers coffee:coffee-script/register test/helper.coffee test/",
     "test-debug": "mocha --debug-brk --ui mocha-gwt --recursive --require coffee-script --compilers coffee:coffee-script/register 'test/helper.coffee' 'test/'",
     "preversion": "git pull --rebase && npm test",
     "postversion": "git push && git push --tags && npm publish"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
     "email": "justin@testdouble.com",
     "url": "http://testdouble.com"
   },
+  "config": {
+    "mocha_reporter": "spec"
+  },
   "scripts": {
-    "test": "mocha --ui mocha-gwt --recursive --require coffee-script --compilers coffee:coffee-script/register test/helper.coffee test/",
+    "test": "mocha --ui mocha-gwt --reporter $npm_package_config_mocha_reporter --recursive --require coffee-script --compilers coffee:coffee-script/register test/helper.coffee test/",
     "test:debug": "npm test -- --debug-brk",
     "preversion": "git pull --rebase && npm test",
     "postversion": "git push && git push --tags && npm publish"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai": "^3.2.0",
     "mocha": "^2.3.1",
     "mocha-gwt": "^0.2.0",
-    "testem": "~0.6.15"
+    "testem": "^0.9.4"
   },
   "keywords": [
     "tdd",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "mocha --ui mocha-gwt --recursive --require coffee-script --compilers coffee:coffee-script/register test/helper.coffee test/",
-    "test-debug": "mocha --debug-brk --ui mocha-gwt --recursive --require coffee-script --compilers coffee:coffee-script/register 'test/helper.coffee' 'test/'",
+    "test:debug": "npm test -- --debug-brk",
     "preversion": "git pull --rebase && npm test",
     "postversion": "git push && git push --tags && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mocha_reporter": "spec"
   },
   "scripts": {
-    "test": "mocha --ui mocha-gwt --reporter $npm_package_config_mocha_reporter --recursive --require coffee-script --compilers coffee:coffee-script/register test/helper.coffee test/",
+    "test": "mocha -u mocha-gwt -R $npm_package_config_mocha_reporter --compilers coffee:coffee-script --recursive test/helper.coffee test/",
     "test:debug": "npm test -- --debug-brk",
     "preversion": "git pull --rebase && npm test",
     "postversion": "git push && git push --tags && npm publish"

--- a/testem.js
+++ b/testem.js
@@ -1,0 +1,11 @@
+var pkg = require('./package.json');
+
+module.exports = {
+  launch_in_dev: [ 'node' ],
+
+  launchers: {
+    node: {
+      command: 'npm test'
+    }
+  }
+};

--- a/testem.js
+++ b/testem.js
@@ -5,7 +5,8 @@ module.exports = {
 
   launchers: {
     node: {
-      command: 'npm test'
+      command: 'npm test --testdouble:mocha_reporter=tap',
+      protocol: 'tap'
     }
   }
 };


### PR DESCRIPTION
Presently, only the node launcher is configured. Browser testing still WIP

`npm start` runs testem (this would be the tdd dev flow)
`npm test` runs mocha (defaulting to spec output, but can be configured via .npmrc) and exits
`npm run test:debug` runs mocha and breaks into debug mode