### PR TITLE
Fixes #21

### DIFF
--- a/lib/create.coffee
+++ b/lib/create.coffee
@@ -11,7 +11,11 @@ module.exports = (nameOrType) ->
 
 createTestDouble = (name) ->
   _.tap createTestDoubleFunction(), (testDouble) ->
-    if name? then store.for(testDouble).name = name
+    if name?
+      store.for(testDouble).name = name
+      testDouble.toString = -> "[test double for \"#{name}\"]"
+    else
+      testDouble.toString = -> "[test double (unnamed)]"
 
 createTestDoubleFunction = ->
   testDouble = (args...) ->

--- a/lib/stringify-args.coffee
+++ b/lib/stringify-args.coffee
@@ -7,6 +7,6 @@ module.exports = (args, joiner = ", ", wrapper = "") ->
 
 stringifyArg = (arg) ->
   try
-    JSON.stringify(arg)
+    JSON.stringify(arg) || arg?.toString?()
   catch e
     "[Circular Object]"

--- a/test/lib/verify-test.coffee
+++ b/test/lib/verify-test.coffee
@@ -44,6 +44,18 @@ describe '.verify', ->
     Then -> expect(@result).to.contain("verification on test double `Foo#baz`.")
     Then -> @testDoubleObj.biz == "not a function!"
 
+  context 'with a test double *as an arg* to another', ->
+    Given -> @testDouble = @create()
+    When -> @result = (shouldThrow => @verify(@testDouble(@someTestDoubleArg)))
+
+    context 'with an unnamed double _as an arg_', ->
+      Given -> @someTestDoubleArg = @create()
+      Then -> expect(@result).to.contain("- called with `([test double (unnamed)])`.")
+
+    context 'with a named double _as an arg_', ->
+      Given -> @someTestDoubleArg = @create("#foo")
+      Then -> expect(@result).to.contain("- called with `([test double for \"#foo\"])`.")
+
   context 'a double-free verification error', ->
     Then -> shouldThrow (=> @verify()), """
       No test double invocation detected for `verify()`.


### PR DESCRIPTION
* define toString on all test doubles. should be safe
* JSON.stringify(arg) on functions returns `undefined` so just `||`'ing here will fall back on toString()

cc/ @BaseCase