### PR TITLE
don't watch generated files

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -16,7 +16,7 @@ module.exports = {
   //after_tests: "rm -rf tmp/browser-test-coffee; rm tmp/subject.js",
 
   test_page: ".browser-testem-view.mustache",
-  src_files: [
+  serve_files: [
     "test/browser-vendor/**/*.js",
     "tmp/browser-test-coffee/browser-helper.js",
     "tmp/browser-test-coffee/general-helper.js",


### PR DESCRIPTION
src_files are served *and* watched. but the src_files are generated JS
files, so each test run generates new js files, which are being watched
so it triggers another build, ad infinitum

testem supports serve_files which are served but not watched (which
requires watch_files to be specified separately)