### PR TITLE
Add an option to ignore additional args

### DIFF
--- a/lib/args-match.coffee
+++ b/lib/args-match.coffee
@@ -1,8 +1,8 @@
 _ = require('lodash')
 
-module.exports = (expectedArgs, actualArgs) ->
+module.exports = (expectedArgs, actualArgs, config) ->
   return true if _.eq(expectedArgs, actualArgs)
-  return false if expectedArgs.length != actualArgs.length
+  return false if expectedArgs.length != actualArgs.length && !config.ignoreExtraArgs
   satisfiesEqualityPlusAnyArgumentMatchers(expectedArgs, actualArgs)
 
 satisfiesEqualityPlusAnyArgumentMatchers = (expectedArgs, actualArgs) ->

--- a/lib/store/calls.coffee
+++ b/lib/store/calls.coffee
@@ -15,12 +15,12 @@ module.exports =
       lastCall = null #<-- no double-dipping since it's global & destructive
       store.for(call.testDouble).calls.pop() if call?
 
-  wasInvoked: (testDouble, args) ->
-    this.where(testDouble, args).length > 0
+  wasInvoked: (testDouble, args, config) ->
+    this.where(testDouble, args, config).length > 0
 
-  where: (testDouble, args) ->
+  where: (testDouble, args, config) ->
     _.select store.for(testDouble).calls, (call) ->
-      argsMatch(args, call.args)
+      argsMatch(args, call.args, config)
 
   for: (testDouble) ->
     store.for(testDouble).calls

--- a/lib/store/stubbings.coffee
+++ b/lib/store/stubbings.coffee
@@ -4,8 +4,8 @@ callsStore = require('./calls')
 argsMatch = require('./../args-match')
 
 module.exports =
-  add: (testDouble, args, stubbedValues) ->
-    store.for(testDouble).stubbings.push({stubbedValues, args})
+  add: (testDouble, args, stubbedValues, config) ->
+    store.for(testDouble).stubbings.push({stubbedValues, args, config})
 
   get: (testDouble, args) ->
     return unless stubbing = stubbingFor(testDouble, args)
@@ -20,5 +20,5 @@ module.exports =
 
 stubbingFor = (testDouble, actualArgs) ->
   _(store.for(testDouble).stubbings).findLast (stubbing) ->
-    argsMatch(stubbing.args, actualArgs)
+    argsMatch(stubbing.args, actualArgs, stubbing.config)
 

--- a/lib/verify.coffee
+++ b/lib/verify.coffee
@@ -3,9 +3,9 @@ store = require('./store')
 callsStore = require('./store/calls')
 stringifyArgs = require('./stringify-args')
 
-module.exports = ->
+module.exports = (__userDoesPretendInvocationHere__, config = {}) ->
   if last = callsStore.pop()
-    if callsStore.wasInvoked(last.testDouble, last.args)
+    if callsStore.wasInvoked(last.testDouble, last.args, config)
       # Do nothing! We're verified! :-D
     else
       throw new Error(unsatisfiedErrorMessage(last.testDouble, last.args))

--- a/lib/when.coffee
+++ b/lib/when.coffee
@@ -1,10 +1,10 @@
 calls = require('./store/calls')
 stubbings = require('./store/stubbings')
 
-module.exports = ->
+module.exports = (__userDoesPretendInvocationHere__, config = {}) ->
   thenReturn: (stubbedValues...) ->
     if last = calls.pop()
-      stubbings.add(last.testDouble, last.args, stubbedValues)
+      stubbings.add(last.testDouble, last.args, stubbedValues, config)
       last.testDouble
     else
       throw new Error """

--- a/test/lib/verify-test.coffee
+++ b/test/lib/verify-test.coffee
@@ -86,3 +86,6 @@ describe '.verify', ->
     context 'unsatisfied', ->
       Then -> shouldThrow(=> @verify(@testDouble(@matchers.isA(String))))
 
+  describe 'ignoring extra arguments (more thoroughly tested via when())', ->
+    When -> @testDouble('matters', 'not')
+    Then -> shouldNotThrow(=> @verify(@testDouble('matters'), ignoreExtraArgs: true))

--- a/test/lib/when-test.coffee
+++ b/test/lib/when-test.coffee
@@ -52,3 +52,27 @@ describe 'when', ->
     Then -> @first == 10
     Then -> @second == 9
     Then -> @third == 9 #<-- last one repeats
+
+  describe 'ignoring extra arguments', ->
+    Given -> @testDouble = @create()
+
+    context 'for a no-arg stubbing', ->
+      Given -> @when(@testDouble(), ignoreExtraArgs: true).thenReturn('pewpew')
+      When -> @result = @testDouble('so', 'many', 'args')
+      Then -> @result == 'pewpew'
+
+    context 'when an initial-arg-matters', ->
+      Given -> @when(@testDouble('important'), ignoreExtraArgs: true).thenReturn('neat')
+
+      context 'satisfied without extra args', ->
+        Then -> @testDouble('important') == 'neat'
+
+      context 'satisfied with extra args', ->
+        Then -> @testDouble('important', 'not important') == 'neat'
+
+      context 'unsatisfied with no args', ->
+        Then -> @testDouble() == undefined
+
+      context 'unsatisfied with extra args', ->
+        Then -> @testDouble('unimportant', 'not important') == undefined
+


### PR DESCRIPTION
Sometimes we don't care about the args when we stub or verify. Sometimes we only care about the first `n` args. In those cases, you can use the `ignoreExtraArgs` option. It's pretty neato.

Resolves #36