### PR TITLE
add info about `verify` failure to the thrown Error

### DIFF
--- a/lib/verify.coffee
+++ b/lib/verify.coffee
@@ -8,7 +8,13 @@ module.exports = (__userDoesPretendInvocationHere__, config = {}) ->
     if callsStore.wasInvoked(last.testDouble, last.args, config)
       # Do nothing! We're verified! :-D
     else
-      throw new Error(unsatisfiedErrorMessage(last.testDouble, last.args, config))
+      err = new Error(unsatisfiedErrorMessage(last.testDouble, last.args, config))
+      err.info =
+        testDouble: last.testDouble
+        calls: callsStore.for last.testDouble
+        expectedArgs: last.args
+        config: config
+      throw err
   else
     throw new Error """
       No test double invocation detected for `verify()`.


### PR DESCRIPTION
I'm working on a plugin for testdouble.js over at https://github.com/BaseCase/testdouble-chai which wraps `verify()` to add custom assertions to `chai`. In order to display useful failure output in my wrapper, I've added an `info` object to the Error that is thrown when `verify` fails.

I totally understand if you want to close this due to not wanting to add data to Errors, not wanting to change testdouble.js for what should be a standalone plugin, etc.! I can most likely accomplish the same goal without these modifications, but it would get messier and more coupled to testdouble internals on the plugin end of things.