### PR TITLE
td.explain tells you if you passed it a test double

### DIFF
--- a/src/explain.coffee
+++ b/src/explain.coffee
@@ -6,14 +6,22 @@ stubbingsStore = require('./store/stubbings')
 stringifyArgs = require('./stringify-args')
 
 module.exports = (testDouble) ->
+  return nullDescription() unless store.for(testDouble, false)?
   calls = callsStore.for(testDouble)
   stubs = stubbingsStore.for(testDouble)
 
   callCount: calls.length
   calls: calls
   description: """
-  This test double #{stringifyName(testDouble)}has #{stubs.length} stubbings and #{calls.length} invocations.
-  """ + stubbingDescription(stubs) + callDescription(calls)
+    This test double #{stringifyName(testDouble)}has #{stubs.length} stubbings and #{calls.length} invocations.
+    """ + stubbingDescription(stubs) + callDescription(calls)
+  isTestDouble: true
+
+nullDescription = ->
+  callCount: 0
+  calls: []
+  description: "This is not a test double."
+  isTestDouble: false
 
 stubbingDescription = (stubs) ->
   return "" if stubs.length == 0

--- a/src/function.coffee
+++ b/src/function.coffee
@@ -5,8 +5,9 @@ stubbings = require('./store/stubbings')
 
 module.exports = (name) ->
   _.tap createTestDoubleFunction(), (testDouble) ->
+    entry = store.for(testDouble, true)
     if name?
-      store.for(testDouble).name = name
+      entry.name = name
       testDouble.toString = -> "[test double for \"#{name}\"]"
     else
       testDouble.toString = -> "[test double (unnamed)]"

--- a/src/store/index.coffee
+++ b/src/store/index.coffee
@@ -5,8 +5,9 @@ globalStore = []
 module.exports =
   reset: -> globalStore = []
 
-  for: (testDouble) ->
+  for: (testDouble, createIfNew = true) ->
     return entry if entry = _(globalStore).find({testDouble})
+    return unless createIfNew
     _.tap initialEntryFor(testDouble), (newEntry) ->
       globalStore.push(newEntry)
 

--- a/test/lib/explain-test.coffee
+++ b/test/lib/explain-test.coffee
@@ -9,6 +9,7 @@ describe '.explain', ->
       description: """
       This test double has 0 stubbings and 0 invocations.
       """
+      isTestDouble: true
 
   context 'a named test double', ->
     Given -> @testDouble = td.function("foobaby")
@@ -39,3 +40,13 @@ describe '.explain', ->
         - called with `(88)`.
         - called with `("not 88", 44)`.
       """
+      isTestDouble: true
+
+  context 'passed a non-test double', ->
+    Given -> @testDouble = 42
+    Then -> expect(@result).to.deep.eq
+      calls: []
+      callCount: 0
+      description: "This is not a test double."
+      isTestDouble: false
+


### PR DESCRIPTION
* Allow td lookups that don't create an entry in the store
This was an oversight to begin with
* td.explain() returns isTestDouble for easy checks of whether
you just passed it a testDouble or not and gives a description
to match