### PR TITLE
Add testdouble-timers as plugin to docs

### DIFF
--- a/docs/A-plugins.md
+++ b/docs/A-plugins.md
@@ -11,6 +11,7 @@ Plugins developed by the community:
 * [testdouble-chai](https://github.com/basecase/testdouble-chai) - Chai assertions
 * [testdouble-jasmine](https://github.com/testdouble/testdouble.js/issues/41) -
 Jasmine `expect` matchers (WIP by @BrianGenisio)
+* [testdouble-timers](https://github.com/kuy/testdouble-timers) - Fake timers API
 
 If you're interested in developing a testdouble.js plugin, we'd love if you
 [opened an issue](https://github.com/testdouble/testdouble.js/issues/new) to


### PR DESCRIPTION
I added [testdouble-timers](https://github.com/kuy/testdouble-timers) to the docs. But I feel that it doesn't fit with the description because `testdouble-timers` doesn't bridge the `verify()` method. Please move my link if you also feel that and separate the section 😄 