### PR TITLE
Fix contains() behavior for arrays

### DIFF
--- a/src/matchers/index.coffee
+++ b/src/matchers/index.coffee
@@ -33,6 +33,8 @@ module.exports =
   contains: create
     name: 'contains'
     matches: (containings, actualArg) ->
+      return false if containings.length == 0
+
       containsAllSpecified = (containing, actual) ->
         _.all containing, (val, key) ->
           return false unless actual?
@@ -42,15 +44,13 @@ module.exports =
             _.eq(val, actual[key])
 
       _.all containings, (containing) ->
-        if _.isString(containing)
-          _.include(actualArg, containing)
-        else if _.isArray(containing)
+        if _.isArray(containing)
           _.any actualArg, (actualElement) ->
             _.eq(actualElement, containing)
-        else if _.isPlainObject(containing)
+        else if _.isPlainObject(containing) && _.isPlainObject(actualArg)
           containsAllSpecified(containing, actualArg)
         else
-          log.error("td.matchers.contains", "this matcher only supports strings, arrays, and plain objects")
+          _.include(actualArg, containing)
 
   argThat: create
     name: 'argThat'

--- a/test/src/matchers-test.coffee
+++ b/test/src/matchers-test.coffee
@@ -80,9 +80,6 @@ describe '.matchers', ->
     context 'strings', ->
       Then -> @matches(td.matchers.contains('bar'), 'foobarbaz') == true
       Then -> @matches(td.matchers.contains('biz'), 'foobarbaz') == false
-      Then -> shouldThrow (=> td.matchers.contains(48).__matches()), """
-        Error: testdouble.js - td.matchers.contains - this matcher only supports strings, arrays, and plain objects
-        """
 
     context 'arrays', ->
       Then -> @matches(td.matchers.contains('a'), ['a','b','c']) == true
@@ -90,6 +87,8 @@ describe '.matchers', ->
       Then -> @matches(td.matchers.contains(['a','c']), ['a','b','c']) == false
       Then -> @matches(td.matchers.contains(['a','c']), [1, ['a','c'], 4]) == true
       Then -> @matches(td.matchers.contains(['a','c']), ['a','b','z']) == false
+      Then -> @matches(td.matchers.contains(true, 5, null, undefined), [true, 5, undefined, null]) == true
+      Then -> @matches(td.matchers.contains(true, 5, null, undefined), [true, 5, null]) == false
 
     context 'objects', ->
       Then -> @matches(td.matchers.contains(foo: 'bar', baz: 42), foo: 'bar', baz: 42, stuff: this) == true
@@ -98,6 +97,12 @@ describe '.matchers', ->
       Then -> @matches(td.matchers.contains(deep: {thing: 'stuff'}), {}) == false
       Then -> @matches(td.matchers.contains(deep: {thing: 'stuff'}), deep: {thing: 'stuff', shallow: 5}) == true
       Then -> @matches(td.matchers.contains({container: {size: 'S'}}), {ingredient: 'beans', container: { type: 'cup', size: 'S'}}) == true
+
+    context 'nonsense', ->
+      Then -> @matches(td.matchers.contains(42), 42) == false
+      Then -> @matches(td.matchers.contains(null), 'shoo') == false
+      Then -> @matches(td.matchers.contains(), 'shoo') == false
+      Then -> @matches(td.matchers.contains({}), undefined) == false
 
   describe 'argThat', ->
     Then -> @matches(td.matchers.argThat((arg) -> arg > 5), 6) == true


### PR DESCRIPTION
Previously, `td.matchers.contains()` behavior for array arguments made no sense and would only work for strings and plain objects, incidentally. The error that was logged should have been targeted at `actualArg`, but it's not fair to log the error based on `actualArg` since it'll cause verifications to appear to fail even if one does satisfy

Thanks a lot to @focusaurus for his patience!

Fixes #102 
