### PR TITLE
Allow nested stubbing configuration

### DIFF
--- a/src/store/calls.coffee
+++ b/src/store/calls.coffee
@@ -2,18 +2,17 @@ _ = require('lodash')
 store = require('./index')
 argsMatch = require('./../args-match')
 
-lastCall = null #<-- remember this to pop our DSL of when(<call>)/verify(<call>)
-store.onReset -> lastCall = null
+callHistory = [] #<-- remember this to pop our DSL of when(<call>)/verify(<call>)
+store.onReset -> callHistory = []
 
 module.exports =
 
   log: (testDouble, args, context) ->
     store.for(testDouble).calls.push({args, context})
-    lastCall = {testDouble, args, context}
+    callHistory.push({testDouble, args, context})
 
   pop: ->
-    _.tap (call = lastCall), (call) ->
-      lastCall = null #<-- no double-dipping since it's global & destructive
+    _.tap (callHistory.pop()), (call) ->
       store.for(call.testDouble).calls.pop() if call?
 
   wasInvoked: (testDouble, args, config) ->

--- a/test/src/when-test.coffee
+++ b/test/src/when-test.coffee
@@ -180,3 +180,10 @@ describe 'when', ->
         When -> @result = [@testDouble(), @testDouble(), @testDouble()]
         Then -> expect(@result).to.deep.equal(['YES', 'NO', 'NO'])
 
+  describe 'nested whens', ->
+    Given -> @knob = td.function()
+    Given -> @door = td.function()
+    Given -> td.when(@knob('twist')).thenReturn
+      door: td.when(@door('push')).thenReturn('open')
+    When -> @result = @knob('twist').door('push')
+    Then -> @result == 'open'


### PR DESCRIPTION
Found this working on a characterization test for @schoonology -- sometimes when test doubles return test doubles (Which they should not do!), nesting stubs for the sake of locality/terseness is preferable over lots of extra variables. It's surprising when this does not work.

Fixes #117