### PR TITLE
Allow for multiple captor invocations

### DIFF
--- a/src/matchers/captor.coffee
+++ b/src/matchers/captor.coffee
@@ -5,9 +5,7 @@ module.exports = ->
     capture: create
       name: 'captor.capture'
       matches: (matcherArgs, actual) ->
-        if not captor.values
-            captor.values = []
+        captor.values ||= []
         captor.values.push actual
         captor.value = actual
         return true
-

--- a/src/matchers/captor.coffee
+++ b/src/matchers/captor.coffee
@@ -5,5 +5,9 @@ module.exports = ->
     capture: create
       name: 'captor.capture'
       matches: (matcherArgs, actual) ->
+        if not captor.values
+            captor.values = []
+        captor.values.push actual
         captor.value = actual
         return true
+

--- a/test/src/captor-test.coffee
+++ b/test/src/captor-test.coffee
@@ -12,5 +12,13 @@ describe 'argument captors (a special sub-type of matchers)', ->
     Given -> @testDouble("SHIRTS!")
     When -> td.verify(@testDouble(@captor.capture()))
     Then -> @captor.value == "SHIRTS!"
+    And -> expect(@captor.values).to.deep.eq ["SHIRTS!"]
+
+  describe 'when verifying multiple', ->
+    Given -> @testDouble("SHIRTS!")
+    And -> @testDouble("SHIRTS AGAIN!")
+    When -> td.verify(@testDouble(@captor.capture()))
+    Then -> @captor.value == "SHIRTS AGAIN!"
+    And -> expect(@captor.values).to.deep.eq ["SHIRTS!", "SHIRTS AGAIN!"]
 
 


### PR DESCRIPTION
Allowing multiple invocations to a captor which will store all captured values in .values. .value still remain for backwards compatibility, and will always contain the last invoked capture value.