### PR TITLE
Fakes properties tacked onto default exported function

### DIFF
--- a/src/replace/imitate-properties.coffee
+++ b/src/replace/imitate-properties.coffee
@@ -1,0 +1,21 @@
+wrapIfNeeded = require('./wrap-if-needed')
+imitate = require('./imitate')
+_ =
+  isFunction: require('lodash/isFunction')
+  keys: require('lodash/keysIn')
+  reduce: require('lodash/reduce')
+  set: require('lodash/set')
+
+module.exports = (realThing) ->
+  return {} unless _.isFunction(realThing)
+  _.reduce imitatableKeys(realThing), wrapKey(realThing), {}
+
+imitatableKeys = (realThing) ->
+  _.keys(realThing).filter (key) ->
+    _.isFunction(realThing[key])
+
+wrapKey = (realThing) -> (newThing, key) ->
+  _.set(newThing, key, wrapIfNeeded(
+    imitate(realThing[key], '.'+key),
+    realThing[key]
+  ))

--- a/src/replace/module.coffee
+++ b/src/replace/module.coffee
@@ -1,14 +1,15 @@
 quibble = require('quibble')
 imitate = require('./imitate')
 wrapIfNeeded = require('./wrap-if-needed')
+imitateProperties = require('./imitate-properties')
 
 quibble.ignoreCallsFromThisFile()
+_ =
+  merge: require('lodash/merge')
 
 module.exports = (path, stub) ->
   return quibble(path, stub) if arguments.length > 1
   realThing = require(quibble.absolutify(path))
   fakeThing = imitate(realThing, path)
   quibble(path, wrapIfNeeded(fakeThing, realThing))
-  return fakeThing
-
-
+  return _.merge(fakeThing, imitateProperties(realThing))

--- a/test/fixtures/car.coffee
+++ b/test/fixtures/car.coffee
@@ -6,3 +6,4 @@ module.exports =
   turn: require('./turn')
   brake: require('./brake')
   lights: require('./lights')
+  shift: require('./shift')

--- a/test/fixtures/shift.js
+++ b/test/fixtures/shift.js
@@ -1,0 +1,9 @@
+function shift() {
+  return 'Faster'
+}
+
+shift.neutral = function() {
+  return 'Coast'
+}
+
+module.exports = shift

--- a/test/src/replace/index-test.coffee
+++ b/test/src/replace/index-test.coffee
@@ -150,6 +150,7 @@ describe 'td.replace', ->
     Given -> @passenger = td.replace('../../fixtures/passenger') #<-- a constructor func
     Given -> @honk = td.replace('../../fixtures/honk') #<-- a plain ol' func
     Given -> @turn = td.replace('../../fixtures/turn') #<-- a named func
+    Given -> @shift = td.replace('../../fixtures/shift') #<-- a named func with property DIRECTION
     Given -> @brake = td.replace('../../fixtures/brake', 'ANYTHING I WANT') #<-- a manual stub bc brake does not exist
     Given -> @lights = td.replace('../../fixtures/lights') #<- a plain object of funcs
     Given -> @car = require('../../fixtures/car')
@@ -166,6 +167,14 @@ describe 'td.replace', ->
       Given -> td.when(@car.turn()).thenReturn('wee')
       Then -> @car.turn() == 'wee'
       And -> @car.turn.toString() == "[test double for \"turn\"]"
+
+    describe 'faking main function when property is also exported', ->
+      Given -> td.when(@car.shift()).thenReturn('Vroom')
+      Then -> @car.shift() == 'Vroom'
+
+    describe 'faking property on exported function', ->
+      Given -> td.when(@car.shift.neutral()).thenReturn('Clunk')
+      Then -> @car.shift.neutral() == 'Clunk'
 
     describe 'manually stubbing an entry', ->
       Then -> @car.brake == 'ANYTHING I WANT'


### PR DESCRIPTION
Replaces imitatable enumerable properties on an exported function.
Does not replace inherited properties.
Allows expected replacement for module like:

``` javascript
function foo() {}
foo.bar = function() {}
module.exports = foo
```

Closes #99

Although not explicitely tested, this will also work for a module like:

``` javascript
module.exports = function foo() {}
modue.exports.bar = function() {}
```
