### PR TITLE
Add failing test for resetting replaced modules.

### DIFF
--- a/test/src/replace/index-test.coffee
+++ b/test/src/replace/index-test.coffee
@@ -148,3 +148,7 @@ describe 'td.replace', ->
       Then -> @car.lights.headlight.toString() == '[test double for ".headlight"]'
       And -> @car.lights.turnSignal.toString() == '[test double for ".turnSignal"]'
       And -> @car.lights.count == 4
+
+    describe 'post-reset usage', ->
+      Given -> td.reset()
+      Then -> @car.honk.toString() == "throw 'honk'"


### PR DESCRIPTION
While not as useful as a fix patch, this is a (currently) failing test that shows how I (currently) expect `replace` and `reset` to work together. Let me know if either is wrong.