### PR TITLE
Changes real call summary to display times called

### DIFF
--- a/src/verify.coffee
+++ b/src/verify.coffee
@@ -39,17 +39,19 @@ unsatisfiedErrorMessage = (testDouble, args, config) ->
 
     Wanted:
       - called with `(#{stringifyArgs(args)})`#{timesMessage(config)}#{ignoreMessage(config)}.
-  """ + invocationSummary(testDouble)
+  """ + invocationSummary(testDouble, config)
 
 stringifyName = (testDouble) ->
   if name = store.for(testDouble).name
     " `#{name}`"
   else
     ""
-invocationSummary = (testDouble) ->
+invocationSummary = (testDouble, config) ->
   calls = callsStore.for(testDouble)
   if calls.length == 0
     "\n\n  But there were no invocations of the test double."
+  else if config.times? && config.times != calls.length
+    "\n\n  But was actually called:\n    - called with `(#{stringifyArgs(calls[0].args)})` #{calls.length} time#{if calls.length == 1 then '' else 's'}."
   else
     _.reduce calls, (desc, call) ->
       desc + "\n    - called with `(#{stringifyArgs(call.args)})`."

--- a/test/src/verify-test.coffee
+++ b/test/src/verify-test.coffee
@@ -124,7 +124,7 @@ describe '.verify', ->
               - called with `()` 0 times.
 
             But was actually called:
-              - called with `()`.
+              - called with `()` 1 time.
           """
 
       context '1 time, satisfied', ->
@@ -141,8 +141,7 @@ describe '.verify', ->
               - called with `()` 1 time.
 
             But was actually called:
-              - called with `()`.
-              - called with `()`.
+              - called with `()` 2 times.
           """
 
       context '4 times, satisfied', ->
@@ -163,9 +162,7 @@ describe '.verify', ->
               - called with `()` 4 times.
 
             But was actually called:
-              - called with `()`.
-              - called with `()`.
-              - called with `()`.
+              - called with `()` 3 times.
           """
 
   describe 'warning when verifying a stubbed invocation', ->


### PR DESCRIPTION
This is a starting place to close #85. There is something that this solution does not account for.

What should happen in a situation where the use wants to verify that a test double is called 2 times, but it was called 3 times with different arguments?