### PR TITLE
Typings for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
 export type TestDouble = Function;
 
-export type DoubledObjectWithKey<Key extends string> = {
-  [P in Key]: TestDouble;
-};
+export type DoubledObjectWithKey<Key extends string> = {};
 
 export type DoubledObject<Subject> = Subject;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,3 +40,28 @@ export type Matchers = {
 };
 
 export const matchers: Matchers;
+
+export function replace(path: string, f?: any): void;
+export function replace(path: {}, property: string, f?: any): void;
+
+export function reset(): void;
+
+export type VerificationConfig = {
+  ignoreExtraArgs?: boolean;
+  times?: number;
+};
+
+export function verify(a: any, check?: VerificationConfig): void;
+
+type Call = {
+  context: {};
+  args: any[];
+};
+
+export type Explanation = {
+  callCount: number;
+  calls: Call[];
+  description: string;
+}
+
+export function explain(f: TestDouble): Explanation;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,42 @@
+export type TestDouble = Function;
+
+export type DoubledObjectWithKey<Key extends string> = {
+  [P in Key]: TestDouble;
+};
+
+export type DoubledObject<Subject> = Subject;
+
+declare function functionDouble(name?: string): TestDouble;
+export { functionDouble as function };
+
+// When passed class or constructor function
+export function object<T>(constructor: { new (): T }): DoubledObject<T>;
+
+// When passed array of props
+export function object<Key extends string>(props: Key[]): DoubledObjectWithKey<Key>;
+
+// When passed general object
+export function object<T>(object: T): DoubledObject<T>;
+
+export type Stubber = {
+  thenReturn(...args: any[]): TestDouble;
+  thenDo(f: Function): TestDouble;
+  thenThrow(e: Error): TestDouble;
+  thenResolve(v: any): TestDouble;
+  thenReject(e: Error): TestDouble;
+  thenCallback(...args: any[]): TestDouble;
+}
+
+export function callback(...args: any[]): void;
+
+export function when(...args: any[]): Stubber;
+
+export type Matchers = {
+  anything(): any;
+  isA(type: Function): any;
+  contains(a: string|any[]|{}): any;
+  argThat(matcher: Function): any;
+  not(v: any): any;
+};
+
+export const matchers: Matchers;

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "test:cover:report": "codeclimate-test-reporter < .coverage/lcov.info",
     "test:cover": "npm run compile:node && npm run test:cover:instrument && npm run test:cover:run",
     "test:browser": "npm run compile && testem ci",
+    "test:typescript": "tsc --noEmit -p ./test/src/typescript",
     "test:example:webpack": "cd examples/webpack && npm i && npm test & cd ../..",
     "test:example:node": "cd examples/node && npm i && npm test && cd ../..",
     "test:example:lineman": "cd examples/lineman && npm i && npm test && cd ../..",
     "test:example:babel": "cd examples/babel && npm i && npm test && cd ../..",
     "test:example": "npm run test:example:node && npm run test:example:lineman && npm run test:example:webpack && npm run test:example:babel",
-    "test:all": "npm test && testem ci && npm run test:example",
+    "test:all": "npm test && testem ci && npm run test:example && npm run test:typescript",
     "test:ci": "npm run clean && npm run compile && npm run test:all && npm run clean:dist && echo \"All done!\"",
     "test:debug": "npm test -- --debug-brk",
     "version:write": "echo \"module.exports = '$npm_package_version'\" > src/version.coffee",
@@ -63,8 +64,10 @@
     "mocha-istanbul": "arikon/mocha-istanbul",
     "pryjs": "^1.0.3",
     "semver": "^5.3.0",
-    "testem": "^0.9.4"
+    "testem": "^0.9.4",
+    "typescript": "^2.1.4"
   },
+  "typings": "./index.d.ts",
   "keywords": [
     "tdd",
     "bdd",

--- a/test/src/typescript/test.ts
+++ b/test/src/typescript/test.ts
@@ -1,0 +1,21 @@
+import * as td from "../../../";
+
+const f = td.function();
+td.when(f(10)).thenReturn(10);
+td.when(f(1)).thenThrow(new Error("ok"));
+td.when(f(td.matchers.isA(String))).thenDo(function(s: string) { return s; });
+td.when(f(td.matchers.not(true))).thenResolve("value");
+td.when(f(td.matchers.not(false))).thenReject(new Error("rejected"));
+
+class Dog {
+  bark() {}
+}
+
+const dog = td.object(Dog);
+td.when(dog.bark()).thenReturn("bark!");
+
+const cat = td.object(["meow"]);
+td.when(cat.meow()).thenReturn("meow!");
+
+const bird = td.object({ fly: function(){} });
+td.when(bird.fly()).thenReturn("fly!");

--- a/test/src/typescript/test.ts
+++ b/test/src/typescript/test.ts
@@ -19,3 +19,20 @@ td.when(cat.meow()).thenReturn("meow!");
 
 const bird = td.object({ fly: function(){} });
 td.when(bird.fly()).thenReturn("fly!");
+
+td.replace({}, "prop");
+td.replace({}, "prop", 42);
+td.replace("../../..");
+td.replace("../../../", 42);
+
+td.verify(f());
+td.verify(f(), { times: 1 });
+td.verify(f(), { ignoreExtraArgs: false });
+td.verify(f(), { ignoreExtraArgs: true, times: 2 });
+
+const explanation = td.explain(f);
+console.log(
+  explanation.description,
+  explanation.calls.length,
+  explanation.callCount
+);

--- a/test/src/typescript/test.ts
+++ b/test/src/typescript/test.ts
@@ -14,9 +14,6 @@ class Dog {
 const dog = td.object(Dog);
 td.when(dog.bark()).thenReturn("bark!");
 
-const cat = td.object(["meow"]);
-td.when(cat.meow()).thenReturn("meow!");
-
 const bird = td.object({ fly: function(){} });
 td.when(bird.fly()).thenReturn("fly!");
 

--- a/test/src/typescript/tsconfig.json
+++ b/test/src/typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "noImplicitAny": true
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/testdouble/testdouble.js/issues/167
I'm not sure about how to test it properly in your configuration, but it looks like my variant would be ok.
I've added feature from new ts 2.1, but it's only needed for one case `td.object(['a', 'b'])`. Also not sure what to add into README.md.