### PR TITLE
Align TS replace() signuatrue return with implementaiton

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,8 +39,8 @@ export type Matchers = {
 
 export const matchers: Matchers;
 
-export function replace(path: string, f?: any): void;
-export function replace(path: {}, property: string, f?: any): void;
+export function replace(path: string, f?: any): any;
+export function replace(path: {}, property: string, f?: any): any;
 
 export function reset(): void;
 


### PR DESCRIPTION
This PR changes the TypeScript type definition for `td.replace()` to return `any` instead of `void`.

Per the [documentation](https://github.com/testdouble/testdouble.js/blob/5cbd55529d6b4cc1d28d27253c03ad3221b691f1/docs/7-replacing-dependencies.md#tdreplace-api):

> ### td.replace(object, propertyName, [manualReplacement])
> [...]
> `td.replace` typically returns the fake thing it sets on `object`, with the
> exception of constructor function properties. In that case, it will return a
> plain object of test double functions to the test, but set `object[propertyName]`
> to a constructor function that delegates to those test double functions only
> after it's been instantiated with `new`.

and

> ### td.replace(relativePathToModule, [manualReplacement])
> [...]
> Once defined, it will return a fake thing based on the same
> inferences discussed above and replace subsequent calls to `require` for that
> module until the next call to `td.reset()`

***

For any downstream users who need these changes sooner, you can add a file to your code named something like `testdouble-overrides.d.ts` with the following content:

```typescript
import 'testdouble';

declare module 'testdouble' {
  export function replace(path: string, f?: any): any;
  export function replace(path: {}, property: string, f?: any): any;
}
```
