### PR TITLE
Captor typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export function object<Key extends string>(props: Key[]): DoubledObjectWithKey<K
 // When passed general object
 export function object<T>(object: T): DoubledObject<T>;
 
-export type Stubber = {
+export interface Stubber {
   thenReturn(...args: any[]): TestDouble;
   thenDo(f: Function): TestDouble;
   thenThrow(e: Error): TestDouble;
@@ -29,13 +29,13 @@ export function callback(...args: any[]): void;
 
 export function when(...args: any[]): Stubber;
 
-export type Matchers = {
+export interface Matchers {
   anything(): any;
   isA(type: Function): any;
   contains(a: string|any[]|{}): any;
   argThat(matcher: Function): any;
   not(v: any): any;
-};
+}
 
 export const matchers: Matchers;
 
@@ -44,19 +44,19 @@ export function replace(path: {}, property: string, f?: any): any;
 
 export function reset(): void;
 
-export type VerificationConfig = {
+export interface VerificationConfig {
   ignoreExtraArgs?: boolean;
   times?: number;
-};
+}
 
 export function verify(a: any, check?: VerificationConfig): void;
 
-type Call = {
+interface Call {
   context: {};
   args: any[];
-};
+}
 
-export type Explanation = {
+export interface Explanation {
   callCount: number;
   calls: Call[];
   description: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,13 @@ export interface Matchers {
   contains(a: string|any[]|{}): any;
   argThat(matcher: Function): any;
   not(v: any): any;
+  captor(): Captor
+}
+
+export interface Captor {
+  capture(): any;
+  value?: any;
+  values?: any[];
 }
 
 export const matchers: Matchers;


### PR DESCRIPTION
This PR:

1. Changes all type aliases to multi-property objects to interfaces.
    - This is a backwards compatible change; it will not affect compilation.
    - Interfaces allow [declaration merging], while type aliases do not. So, if the type definitions fall behind the implementation (for instance, missing the `captor()` function), downstream users can declaration-merge in a patch to keep going until the official type def is updated.
1. Adds `td.matchers.captor()` to the type definitions.

[declaration merging]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html