### PR TITLE
feat: contains allows for regexps against strings

### DIFF
--- a/docs/5-stubbing-results.md
+++ b/docs/5-stubbing-results.md
@@ -182,6 +182,21 @@ yell('ARGHHHHHHH') // 'AYE'
 yell('ARG') // undefined
 ```
 
+###### Regular Expressions
+
+Using `contains` with regexps on string arguments is supported as of v1.11.0 and is also pretty straightforward:
+
+``` javascript
+var yell = td.function()
+
+td.when(yell(td.matchers.contains(/ARGH$/i))).thenReturn('AYE')
+
+yell('ARGH') // 'AYE'
+yell('ARGHHHHHHH') // 'undefined'
+yell('argh') // 'AYE'
+yell('ARG') // undefined
+```
+
 ##### Arrays
 
 Here's how to use `contains` with an array argument:

--- a/src/matchers/index.coffee
+++ b/src/matchers/index.coffee
@@ -50,6 +50,8 @@ module.exports =
             _.isEqual(actualElement, containing)
         else if _.isPlainObject(containing) && _.isPlainObject(actualArg)
           containsAllSpecified(containing, actualArg)
+        else if _.isRegExp(containing)
+          containing.test(actualArg)
         else
           _.includes(actualArg, containing)
 

--- a/src/util/lodash-wrap.coffee
+++ b/src/util/lodash-wrap.coffee
@@ -16,6 +16,7 @@ module.exports =
   isFunction: require('lodash/isFunction')
   isNumber: require('lodash/isNumber')
   isPlainObject: require('lodash/isPlainObject')
+  isRegExp: require('lodash/isRegExp')
   isString: require('lodash/isString')
   keys: require('lodash/keys')
   last: require('lodash/last')
@@ -24,4 +25,3 @@ module.exports =
   some: require('lodash/some')
   tap: require('lodash/tap')
   union: require('lodash/union')
-

--- a/test/src/matchers-test.coffee
+++ b/test/src/matchers-test.coffee
@@ -98,6 +98,11 @@ describe '.matchers', ->
       Then -> @matches(td.matchers.contains(deep: {thing: 'stuff'}), deep: {thing: 'stuff', shallow: 5}) == true
       Then -> @matches(td.matchers.contains({container: {size: 'S'}}), {ingredient: 'beans', container: { type: 'cup', size: 'S'}}) == true
 
+    context 'regexp', ->
+      Then -> @matches(td.matchers.contains(/abc/), 'abc') == true
+      Then -> @matches(td.matchers.contains(/abc/), foo: 'bar') == false
+      Then -> @matches(td.matchers.contains(/abc/), ['foo', 'bar']) == false
+
     context 'nonsense', ->
       Then -> @matches(td.matchers.contains(42), 42) == false
       Then -> @matches(td.matchers.contains(null), 'shoo') == false
@@ -112,6 +117,3 @@ describe '.matchers', ->
     Then -> @matches(td.matchers.not(5), 6) == true
     Then -> @matches(td.matchers.not(5), 5) == false
     Then -> @matches(td.matchers.not(['hi']), ['hi']) == false
-
-
-


### PR DESCRIPTION
This is my initial stab at adding RegExp support to the contains matcher. Let me know if/what kind of [other] edge cases you'd like me to cover :)

Also if this is not considered to be a good idea, I'd love to know why that decision was made. If I understand the `argThat` matcher correctly, this is just an alias that allows users to inline their assertion in the test which makes them read better IMHO leading to easier maintainability.