### PR TITLE
Improves warning when verifying a stub

### DIFF
--- a/src/verify.coffee
+++ b/src/verify.coffee
@@ -24,7 +24,7 @@ module.exports = (__userDoesPretendInvocationHere__, config = {}) ->
 
 warnIfStubbed = (testDouble, actualArgs) ->
   _.find stubbingsStore.for(testDouble), (stubbing) ->
-    if argsMatch(stubbing.args, actualArgs, allowMatchers: false)
+    if argsMatch(stubbing.args, actualArgs, stubbing.config)
       log.warn 'td.verify', """
       test double#{stringifyName(testDouble)} was both stubbed and verified with arguments (#{stringifyArgs(actualArgs)}), which is redundant and probably unnecessary.
       """, "https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double"

--- a/test/src/verify-test.coffee
+++ b/test/src/verify-test.coffee
@@ -175,17 +175,34 @@ describe '.verify', ->
     afterEach = console.warn = @ogWarn
     Given -> @td = td.function('.foo')
 
-    context 'an exact match in calls', ->
-      Given -> td.when(@td(1)).thenReturn(5)
-      Given -> @td(1)
-      When -> td.verify(@td(1))
-      Then -> @warnings[0] == """
-        Warning: testdouble.js - td.verify - test double `.foo` was both stubbed and verified with arguments (1), which is redundant and probably unnecessary. (see: https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double )
-        """
+    context 'warn user for', ->
+      context 'an exact match in calls', ->
+        Given -> td.when(@td(1)).thenReturn(5)
+        Given -> @td(1)
+        When -> td.verify(@td(1))
+        Then -> @warnings[0] == """
+          Warning: testdouble.js - td.verify - test double `.foo` was both stubbed and verified with arguments (1), which is redundant and probably unnecessary. (see: https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double )
+          """
 
-    context 'matchers are used', ->
-      Given -> td.when(@td(td.matchers.isA(Number))).thenReturn(5)
-      Given -> @td(1)
-      When -> td.verify(@td(1))
-      Then -> @warnings.length == 0
+      context 'a match where stub ignores extra arguments', ->
+        Given -> td.when(@td(1), {ignoreExtraArgs: true}).thenReturn()
+        Given -> @td(1, 2, 3)
+        When -> td.verify(@td(1, 2, 3))
+        Then -> @warnings[0] == """
+          Warning: testdouble.js - td.verify - test double `.foo` was both stubbed and verified with arguments (1, 2, 3), which is redundant and probably unnecessary. (see: https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double )
+          """
 
+      context 'a match where stub uses a matcher', ->
+        Given -> td.when(@td(td.matchers.isA(Number))).thenReturn(5)
+        Given -> @td(1)
+        When -> td.verify(@td(1))
+        Then -> @warnings[0] == """
+          Warning: testdouble.js - td.verify - test double `.foo` was both stubbed and verified with arguments (1), which is redundant and probably unnecessary. (see: https://github.com/testdouble/testdouble.js/blob/master/docs/B-frequently-asked-questions.md#why-shouldnt-i-call-both-tdwhen-and-tdverify-for-a-single-interaction-with-a-test-double )
+          """
+
+    context "don't warn user when", ->
+      context "verify doesn't match the stub", ->
+        Given -> td.when(@td(1)).thenReturn()
+        Given -> @td()
+        When -> td.verify(@td())
+        Then -> @warnings.length == 0


### PR DESCRIPTION
After a verification is made, a warning can be produced to signal that
the verification call matches a stub on the same testdouble. This
behavior is improved to test the verification against the stubbing using
the stubs matchers and config options.

This closes: stub also verified warning when using ignoreExtraArgs #181
completed with @tinney