### PR TITLE
Preserve function context when calling thenDo

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -31,5 +31,5 @@ var createTestDoubleNamed = (name) =>
 var createTestDoubleFunction = () =>
   function testDouble (...args) {
     calls.log(testDouble, args, this)
-    return stubbings.invoke(testDouble, args)
+    return stubbings.invoke(this, testDouble, args)
   }

--- a/src/store/stubbings.js
+++ b/src/store/stubbings.js
@@ -15,10 +15,10 @@ module.exports = {
     })
   },
 
-  invoke (testDouble, actualArgs) {
+  invoke (context, testDouble, actualArgs) {
     const stubbing = stubbingFor(testDouble, actualArgs)
     if (stubbing) {
-      return executePlan(stubbing, actualArgs)
+      return executePlan(context, stubbing, actualArgs)
     }
   },
 
@@ -31,13 +31,13 @@ var stubbingFor = (testDouble, actualArgs) =>
   _.findLast(store.for(testDouble).stubbings, stubbing =>
     isSatisfied(stubbing, actualArgs))
 
-var executePlan = (stubbing, actualArgs) => {
+var executePlan = (context, stubbing, actualArgs) => {
   const value = stubbedValueFor(stubbing)
   stubbing.callCount += 1
   invokeCallbackFor(stubbing, actualArgs)
   switch (stubbing.config.plan) {
     case 'thenReturn': return value
-    case 'thenDo': return value(...actualArgs)
+    case 'thenDo': return value.apply(context, actualArgs)
     case 'thenThrow': throw value
     case 'thenResolve': return createPromise(stubbing, value, true)
     case 'thenReject': return createPromise(stubbing, value, false)

--- a/test/src/when-test.coffee
+++ b/test/src/when-test.coffee
@@ -90,6 +90,11 @@ describe 'when', ->
     When -> @result = @testDouble(55)
     And -> @result == 'yatta'
 
+  describe 'stubbing actions with `thenDo` preserves function context', ->
+    Given -> td.when(@testDouble(55)).thenDo(-> this.result)
+    When -> @result = @testDouble.call({ result: 'yatta' }, 55)
+    Then -> @result == 'yatta'
+
   describe 'stubbing actions with `thenThrow` instead of `thenReturn`', ->
     Given -> @error = new Error('lol')
     Given -> td.when(@testDouble(42)).thenThrow(@error)


### PR DESCRIPTION
This is required for some APIs where we might not have access to, but require (e.g. in fluent chains) the instance the function is being called on ahead of time.

You can be double-sure this works because I implemented it in both CoffeeScript and JavaScript, as #206 was merged while I was writing it 😉 