### PR TITLE
Add failing test for resetting replaced modules.

### DIFF
--- a/test/src/replace/index-test.coffee
+++ b/test/src/replace/index-test.coffee
@@ -186,3 +186,7 @@ describe 'td.replace', ->
       describe 'and classes on objects on funcs', ->
         When -> td.when(@lights.brights.prototype.beBright(1)).thenReturn('yow')
         Then -> (new @car.lights.brights).beBright(1) == 'yow'
+
+    describe 'post-reset usage', ->
+      Given -> td.reset()
+      Then -> @car.honk.toString() == "throw 'honk'"


### PR DESCRIPTION
I think we discussed this case a long time ago, but this test fails when trying to `td.reset` a quibble-replaced module: the test double is still there.