### PR TITLE
Add example failing test for td.explain(object).

### DIFF
--- a/test/src/explain-test.coffee
+++ b/test/src/explain-test.coffee
@@ -95,3 +95,17 @@ describe '.explain', ->
       callCount: 0
       description: "This is not a test double."
       isTestDouble: false
+
+  context 'a bag of doubles', ->
+    Given -> @testDouble = td.object(['example'])
+    Then ->
+      console.log @result
+      expect(@result).to.deep.eq
+        name: undefined
+        callCount: 0
+        description: """
+        This is a bag of the following doubles:
+
+        - example (0 stubbings and 0 invocations)
+        """
+        isTestDouble: true


### PR DESCRIPTION
This is just another random thought, but I found myself instinctively trying the following while test-driving a feature this week:

```
var bag = td.object(['some_method'])
...
td.explain(bag)
```

While it was immediately obvious both that we don't support this behaviour now and that what I wanted was `td.explain(bag.some_method)`, it left me wondering how desirable this behaviour would be. I know it would require substantial changes to the way `explain` and `store` interact. (If it was easier, this PR would include the working feature!)