### PR TITLE
Avoid calling super() when extending ES classes

### DIFF
--- a/src/constructor.js
+++ b/src/constructor.js
@@ -13,8 +13,9 @@ var fakeConstructorFromType = (type) => {
 
   return _.tap(class TestDoubleConstructor extends type {
     constructor () {
-      super(...arguments)
+//      super(...arguments)
       fauxConstructor(...arguments)
+      return Object.create(new.target.prototype, {})
     }
   }, (fakeType) => {
     // Override "static" functions with instance test doubles


### PR DESCRIPTION
Got the idea from: http://stackoverflow.com/questions/31067368/javascript-es6-class-extend-without-super

Tested it in this runkit:

https://runkit.com/searls/avoiding-calling-super-in-an-extended-class

Resolves #241