### PR TITLE
Stop extending types when replacing constructors

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,8 +3,9 @@ import log from './log'
 import stringifyAnything from './stringify/anything'
 
 const DEFAULTS = {
-  promiseConstructor: global.Promise,
+  extendWhenReplacingConstructors: false,
   ignoreWarnings: false,
+  promiseConstructor: global.Promise,
   suppressErrors: false
 }
 let configData = _.extend({}, DEFAULTS)

--- a/src/constructor.js
+++ b/src/constructor.js
@@ -2,6 +2,7 @@ import _ from './util/lodash-wrap'
 import getAllCustomPrototypalFunctionNames from './util/get-all-custom-prototypal-function-names'
 import tdFunction from './function'
 import config from './config'
+import copyProperties from './util/copy-properties'
 
 export default (typeOrNames) =>
   _.isFunction(typeOrNames)
@@ -11,6 +12,8 @@ export default (typeOrNames) =>
 var fakeConstructorFromType = (type) =>
   _.tap(createFakeType(type), (fakeType) => {
     const name = type.name || ''
+    copyProperties(type, fakeType)
+    copyProperties(type.prototype, fakeType.prototype)
 
     // Override "static" functions with instance test doubles
     _.each(_.functions(type), funcName => {

--- a/test/src/config-test.js
+++ b/test/src/config-test.js
@@ -1,8 +1,9 @@
 describe('td.config', () => {
   it('sets some ok defaults', () => {
     expect(td.config()).to.deep.equal({
-      promiseConstructor: global.Promise,
+      extendWhenReplacingConstructors: false,
       ignoreWarnings: false,
+      promiseConstructor: global.Promise,
       suppressErrors: false
     })
   })
@@ -21,7 +22,7 @@ describe('td.config', () => {
 
     expect(error.message).to.eq(
       'Error: testdouble.js - td.config - "wat" is not a valid configuration ' +
-      'key (valid keys are: ["promiseConstructor", "ignoreWarnings", ' +
-      '"suppressErrors"])')
+      'key (valid keys are: [\n  "extendWhenReplacingConstructors",\n  "ignoreWarnings",' +
+      '\n  "promiseConstructor",\n  "suppressErrors"\n])')
   })
 })

--- a/test/src/constructor-test.coffee
+++ b/test/src/constructor-test.coffee
@@ -39,8 +39,15 @@ describe 'td.constructor', ->
     Then -> @fakeConstructor.bar.toString() == '[test double for "Thing.bar"]'
     Then -> @fakeInstance.toString() == '[test double instance of constructor "Thing"]'
 
-    # Fake things pass instanceof checks
-    Then -> @fakeInstance instanceof Thing
+    context 'extendWhenReplacingConstructors disabled (default)', ->
+      Then -> td.config().extendWhenReplacingConstructors == false
+      Then -> !(@fakeInstance instanceof Thing)
+
+    context 'extendWhenReplacingConstructors enabled', ->
+      Given -> td.config(extendWhenReplacingConstructors: true)
+      # Fake things pass instanceof checks
+      Then -> td.config().extendWhenReplacingConstructors == true
+      Then -> @fakeInstance instanceof Thing
 
     # Original attributes are carried over
     Then -> @fakeConstructor.prototype.instanceAttr == 'baz'

--- a/test/src/constructor-test.coffee
+++ b/test/src/constructor-test.coffee
@@ -45,8 +45,7 @@ describe 'td.constructor', ->
 
     context 'extendWhenReplacingConstructors enabled', ->
       Given -> td.config(extendWhenReplacingConstructors: true)
-      # Fake things pass instanceof checks
-      Then -> td.config().extendWhenReplacingConstructors == true
+      Given -> @fakeInstance = new (td.constructor(Thing))()
       Then -> @fakeInstance instanceof Thing
 
     # Original attributes are carried over


### PR DESCRIPTION
**This is a breaking change**

I made a mistake in td 2.0 and it took too long to catch. Mea culpa. I feel bad.

## What went wrong

I've decided after fighting various babel shenanigans to give up on trying to create test double constructors that will pass instanceof checks. The reality is that the ES Class spec buttons up any cuteness I'd been able to previously get away with, namely

1. There's no way to pass an `instanceof` check of a class without extending it
2. There's no way to extend a class without invoking the super constructor upon instantiation (the sole alternative is to instantiate it manually and return that from the sub constructor, but for our purposes that has the same downside—production code of a dependency getting executed by a unit test).
3. We have since learned that when babel-transpiled code attempts to extend a bona fide ES class, all hell breaks loose, and there's no real way to work around it currently. Namely, the babel-transpiled constructor will attempt to call the superclass constructor without `new`, which violates a runtime check of the ES class spec.

## New behavior

Going forward, `td.replace()` on constructors will not extend the original type, and will instead copy over attribute values and imitate functions. The previous behavior will be hidden behind a global configuration option called `td.config({extendWhenReplacingConstructors: false})` for the handful of folks who really want their test doubles to pass `instanceof` checks (which I suspect is a small minority, given how sparingly the `instanceof` keyword is typically used).
