### PR TITLE
Test testdouble.js with testdouble.js!

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "justin@testdouble.com",
     "url": "http://testdouble.com"
   },
-  "main": "lib/testdouble.js",
+  "main": "lib/index.js",
   "config": {
     "build_file": "dist/testdouble.js",
     "test_bundle": "generated/tests.js",
@@ -17,7 +17,7 @@
   "scripts": {
     "clean": "rm -rf generated dist lib coverage && yarn run clean:dist",
     "clean:dist": "git checkout -- dist",
-    "compile:browser": "browserify src/testdouble.js --standalone td --outfile $npm_package_config_build_file -p headerify -t babelify",
+    "compile:browser": "browserify src/index.js --standalone td --outfile $npm_package_config_build_file -p headerify -t babelify",
     "compile:browser:test": "mkdir -p generated && browserify test/browser-helper.js --outfile $npm_package_config_test_bundle -t babelify -t coffeeify --extension=\".coffee\" -t require-globify --ignore-missing",
     "compile:node": "babel src -d lib",
     "compile": "yarn run compile:node && yarn run compile:browser && yarn run compile:browser:test",
@@ -25,8 +25,9 @@
     "cover:report": "codeclimate-test-reporter < coverage/lcov.info",
     "style": "standard \"./src/**/*\" --fix",
     "test": "mocha --ui mocha-given --reporter $npm_package_config_mocha_reporter --compilers js:babel-core/register,coffee:coffee-script --recursive test/node-helper.coffee test/src",
-    "test:all": "yarn test && yarn run test:browser && yarn run test:example && yarn run test:typescript",
+    "test:all": "yarn test:unit && yarn test && yarn run test:browser && yarn run test:example && yarn run test:typescript",
     "test:browser": "testem ci",
+    "test:unit": "teenytest",
     "test:ci": "yarn run clean && yarn run compile && yarn run style && yarn run test:all && yarn run clean:dist && echo \"All done!\"",
     "test:typescript": "tsc --noEmit -p ./test/src/typescript",
     "test:example:webpack": "cd examples/webpack && yarn install && yarn test && cd ../..",
@@ -45,6 +46,10 @@
     "presets": [
       "env"
     ]
+  },
+  "teenytest": {
+    "testLocator": "unit/**/*.test.js",
+    "helper": "unit/helper.js"
   },
   "browser": {
     "./lib/replace/module.js": "./lib/replace/module.browser.js",
@@ -73,6 +78,7 @@
     "codeclimate-test-reporter": "^0.4.1",
     "coffee-script": "^1.10.0",
     "coffeeify": "^2.1.0",
+    "core-assert": "^0.2.1",
     "headerify": "^1.0.1",
     "is-number": "^3.0.0",
     "mocha": "^3.2.0",
@@ -81,6 +87,8 @@
     "pryjs": "^1.0.3",
     "require-globify": "^1.4.1",
     "standard": "^9.0.2",
+    "teenytest": "^5.0.2",
+    "testdouble": "3.0.0",
     "testem": "^1.15.0",
     "typescript": "^2.2.1"
   },

--- a/script/repl
+++ b/script/repl
@@ -5,7 +5,7 @@ require('babel-core/register')
 var repl = require('repl')
 
 console.log('💚  Let\'s play with testdouble.js!  💚')
-global.td = require('../src/testdouble')
+global.td = require('../src')
 global._ = require('lodash')
 repl.start('td > ')
 

--- a/src/callback.js
+++ b/src/callback.js
@@ -1,5 +1,5 @@
-import _ from '../util/lodash-wrap'
-import create from './create'
+import _ from './util/lodash-wrap'
+import create from './matchers/create'
 
 export default _.tap(create({
   name: 'callback',

--- a/src/function/create.js
+++ b/src/function/create.js
@@ -1,0 +1,1 @@
+export default () => {}

--- a/src/function/imitate.js
+++ b/src/function/imitate.js
@@ -1,0 +1,1 @@
+export default () => {}

--- a/src/function/index.js
+++ b/src/function/index.js
@@ -1,0 +1,10 @@
+import _ from '../wrap/lodash'
+
+import create from './create'
+import imitate from './imitate'
+import remember from './remember'
+
+export default (nameOrFunc) =>
+  _.isFunction(nameOrFunc)
+    ? remember(imitate(nameOrFunc, create(nameOrFunc.name)), nameOrFunc.name)
+    : remember(create(nameOrFunc), nameOrFunc)

--- a/src/function/remember.js
+++ b/src/function/remember.js
@@ -1,0 +1,1 @@
+export default () => {}

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import replace from './replace'
 import explain from './explain'
 import reset from './reset'
 import config from './config'
-import callback from './matchers/callback'
+import callback from './callback'
 import version from './version'
 
 module.exports = {

--- a/src/store/stubbings.js
+++ b/src/store/stubbings.js
@@ -1,6 +1,6 @@
 import _ from '../util/lodash-wrap'
 import argsMatch from '../args-match'
-import callback from '../matchers/callback'
+import callback from '../callback'
 import config from '../config'
 import log from '../log'
 import store from './index'

--- a/src/when.js
+++ b/src/when.js
@@ -1,5 +1,5 @@
 import _ from './util/lodash-wrap'
-import callback from './matchers/callback'
+import callback from './callback'
 import calls from './store/calls'
 import log from './log'
 import stubbings from './store/stubbings'

--- a/src/wrap/lodash.js
+++ b/src/wrap/lodash.js
@@ -1,0 +1,1 @@
+../util/lodash-wrap.js

--- a/test/browser-helper.js
+++ b/test/browser-helper.js
@@ -2,7 +2,7 @@ require('mocha-given/browser/mocha-given')
 mocha.setup('mocha-given')
 global.NODE_JS = false
 
-global.td = require('../src/testdouble')
+global.td = require('../src')
 require('./general-helper')
 
 // Require all the tests so they're included in the browserify build:

--- a/test/node-helper.coffee
+++ b/test/node-helper.coffee
@@ -3,5 +3,5 @@ global.NODE_JS = true
 
 global.pry = require('pryjs')
 
-global.td = require('../src/testdouble')
+global.td = require('../src')
 require('./general-helper')

--- a/test/src/testdouble-test.coffee
+++ b/test/src/testdouble-test.coffee
@@ -7,7 +7,7 @@ describe "td.*", ->
     Then -> td.object == require('../../src/object').default
     Then -> td.constructor == require('../../src/constructor').default
     Then -> td.matchers == require('../../src/matchers').default
-    Then -> td.callback == require('../../src/matchers/callback').default
+    Then -> td.callback == require('../../src/callback').default
     Then -> td.explain == require('../../src/explain').default
     Then -> td.reset == require('../../src/reset').default
     Then -> td.replace == require('../../src/replace').default

--- a/unit/function/index.test.js
+++ b/unit/function/index.test.js
@@ -1,0 +1,33 @@
+    // 1. create the function
+    //    - tack on a tostring method that prints the name
+    // 2. (if passed a func), copy-props & shallow td-ify
+    // 3 throws it in the "store"
+    //   - assigns the name to the entry in the store (if it exists)
+let create, imitate, remember, subject
+module.exports = {
+  beforeEach: () => {
+    create = td.replace('../../src/function/create').default
+    imitate = td.replace('../../src/function/imitate').default
+    remember = td.replace('../../src/function/remember').default
+
+    subject = require('../../src/function/index').default
+  },
+  'pass in a name': () => {
+    td.when(create('foo')).thenReturn('a fake foo')
+    td.when(remember('a fake foo', 'foo')).thenReturn('a remembered foo')
+
+    const result = subject('foo')
+
+    assert.equal(result, 'a remembered foo')
+  },
+  'pass in a function': () => {
+    const bar = function bar () {}
+    td.when(create('bar')).thenReturn('a fake bar')
+    td.when(imitate(bar, 'a fake bar')).thenReturn('an imitated bar')
+    td.when(remember('an imitated bar', 'bar')).thenReturn('a remembered bar')
+
+    const result = subject(bar)
+
+    assert.equal(result, 'a remembered bar')
+  }
+}

--- a/unit/helper.js
+++ b/unit/helper.js
@@ -1,0 +1,11 @@
+require('babel-core/register')
+global.assert = require('core-assert')
+global.td = require('testdouble') //<-- a known previous devDep version!!!!
+global.pry = require('pryjs')
+
+module.exports = {
+  beforeAll: function () {},
+  beforeEach: function () {},
+  afterEach: function () {},
+  afterAll: function () {}
+}

--- a/unit/index.test.js
+++ b/unit/index.test.js
@@ -1,0 +1,36 @@
+
+module.exports = () => {
+  // Creation
+  const object = td.replace('../src/object').default
+  const func = td.replace('../src/function').default
+  const constructor = td.replace('../src/constructor').default
+  const replace = td.replace('../src/replace').default
+  // Stubbing & Verifying
+  const when = td.replace('../src/when').default
+  const verify = td.replace('../src/verify').default
+  const matchers = td.replace('../src/matchers').default
+  const callback = td.replace('../src/callback').default
+  // Misc.
+  const explain = td.replace('../src/explain').default
+  const reset = td.replace('../src/reset').default
+  const config = td.replace('../src/config').default
+  const version = td.replace('../src/version').default
+
+  const subject = require('../src')
+
+  assert.deepEqual(subject, {
+    func: func,
+    function: func,
+    object: object,
+    constructor: constructor,
+    replace: replace,
+    when: when,
+    verify: verify,
+    matchers: matchers,
+    callback: callback,
+    explain: explain,
+    reset: reset,
+    config: config,
+    version: version
+  })
+}

--- a/unit/index.test.js
+++ b/unit/index.test.js
@@ -1,8 +1,7 @@
-
 module.exports = () => {
   // Creation
-  const object = td.replace('../src/object').default
   const func = td.replace('../src/function').default
+  const object = td.replace('../src/object').default
   const constructor = td.replace('../src/constructor').default
   const replace = td.replace('../src/replace').default
   // Stubbing & Verifying

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ acorn@4.0.4, acorn@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
-acorn@^3.0.0, acorn@^3.0.4:
+acorn@^3.0.0, acorn@^3.0.4, acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
@@ -210,7 +210,7 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.4.0, async@^1.4.2, async@~1.5.2:
+async@^1.4.0, async@^1.4.2, async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -968,6 +968,10 @@ browserslist@^1.4.0:
     caniuse-db "^1.0.30000631"
     electron-to-chromium "^1.2.5"
 
+buf-compare@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -1260,6 +1264,13 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+core-assert@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/core-assert/-/core-assert-0.2.1.tgz#f85e2cf9bfed28f773cc8b3fa5c5b69bdc02fe3f"
+  dependencies:
+    buf-compare "^1.0.0"
+    is-error "^2.2.0"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -2047,6 +2058,12 @@ function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+function-names-at-line@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/function-names-at-line/-/function-names-at-line-1.0.0.tgz#3441d99ed2c7efbaf38a850b193c51e139a54c5f"
+  dependencies:
+    acorn "^3.1.0"
+
 gauge@~2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.3.tgz#1c23855f962f17b3ad3d0dc7443f304542edfe09"
@@ -2105,6 +2122,16 @@ glob@7.0.5:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2425,6 +2452,10 @@ is-equal-shallow@^0.1.3:
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
   dependencies:
     is-primitive "^2.0.0"
+
+is-error@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.1.tgz#684a96d84076577c98f4cdb40c6d26a5123bf19c"
 
 is-extendable@^0.1.1:
   version "0.1.1"
@@ -2764,6 +2795,12 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-deeper@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lodash-deeper/-/lodash-deeper-1.1.0.tgz#5af51f33cb0bf5e24a08187c326b779a17e489dc"
+  dependencies:
+    lodash ">=4.13.1"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -2847,7 +2884,7 @@ lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
+lodash@>=4.13.1, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2943,7 +2980,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -3750,7 +3787,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
@@ -4202,6 +4239,18 @@ tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+teenytest@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/teenytest/-/teenytest-5.0.2.tgz#e6d6f8ec38835b1e2383147e0904ff4832bda498"
+  dependencies:
+    async "^1.5.2"
+    function-names-at-line "^1.0.0"
+    glob "^6.0.4"
+    lodash "^4.13.1"
+    lodash-deeper "^1.0.0"
+    minimist "^1.2.0"
+    resolve "^1.1.7"
+
 test-exclude@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-3.3.0.tgz#7a17ca1239988c98367b0621456dbb7d4bc38977"
@@ -4211,6 +4260,15 @@ test-exclude@^3.3.0:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+testdouble@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/testdouble/-/testdouble-3.0.0.tgz#fa11412ab5009ce9e3838a69419bcf8cba540e13"
+  dependencies:
+    lodash "^4.15.0"
+    quibble "^0.5.0"
+    resolve "^1.3.2"
+    stringify-object-es5 "^2.5.0"
 
 testem@^1.15.0:
   version "1.15.0"


### PR DESCRIPTION
I've never been happy with this library's "unit" test suite because it's
too extrinsic, poking at things only through the top-level exposed td.*
API methods. This is a fine strategy for smaller libraries, but on
larger libraries like this one, it encourages large units and extract
refactors in the src code tend to be more arbitrary and less symmetrical
to the test files, which increases onboarding time for others and adds
some indirection when trying to find the spot in the code that a test is
specifying.

This was done for two reasons at the time, both of which I now regret:

1. testdouble.js didn't exist yet, so doing my brand of Discovery
Testing would be hard.
2. I didn't trust Browserify to work, so I went out of my way at first
to test the built Browserified lib extrinsically in a browser
environment to make sure the build was right, which meant I couldn't
`require` any internals inside the test suite.

As a result, the test suite we have is not a unit suite so much as an
exhaustive functional test suite. This may have made sense at the time,
but Node.js & Browsers have reached a level of maturity and parity that
non-DOM APIs like td.js should be able to run unit tests in Node and
have relative confidence that the same stuff would also pass in browsers
(meaning it no longer makes sense to bend over backwards to run the unit
tests in a native browser environment).

So what this PR is getting started is a *BRAND NEW TEST SUITE* that will
try to dogfood testdouble and "rediscovery test" it from the start,
which will require pretty drastic refactoring and reimagining of the
code structure to feature smaller units, better names, and a strict
hierarchical internal dependency graph.

It accomplishes this by using the mocha/coffeescript/mocha-given functional test
suite as a refactoring backstop (to be deleted after we're done) while
we write a brand new unit test suite in Test Double®'s own teenytest
test framework & a prior known version of testdouble.js (3.0.0 at this
time). That means that testdouble.js may become the first self-hosted
mocking library I know of—neato!

(Pairing on this with @jersearls so far. Anyone else is welcome to pair with me on it, just ping me.)