### PR TITLE
prevent reserved prop names from being overwritten in copy-props

### DIFF
--- a/src/share/copy-props.js
+++ b/src/share/copy-props.js
@@ -2,7 +2,7 @@ import _ from '../wrap/lodash'
 
 export default (original, target, props) => {
   Object.defineProperties(target, _.transform(props, (acc, name) => {
-    if (!(name in original) || name in target) return
+    if (!(name in original) || name in target || name in acc) return
     acc[name] = {
       configurable: true,
       writable: true,

--- a/unit/share/copy-props.test.js
+++ b/unit/share/copy-props.test.js
@@ -52,5 +52,15 @@ module.exports = {
     assert.equal(target.c, 3)
     assert.equal(target.d, 4)
     assert.ok(!('e' in target))
+  },
+  'does not try to overwrite its own reserved props': () => {
+    const original = {a: 1, includes: 3}
+    const target = {b: 2}
+
+    subject(original, target, ['a', 'b', 'includes'])
+
+    assert.equal(target.a, 1)
+    assert.ok(!('includes' in target))
+    assert.equal(target.b, 2)
   }
 }


### PR DESCRIPTION
:wave: hello!

Ok, this is a bit of a doozy. It could be a "Suz, you're not using testdouble properly" thing 🤷‍♀️ 

I used testdouble.js to [add a unit test to a library of mine](https://github.com/noopkat/oled-js/commit/4d38879ab92cda11bc0f13104be66d2b6711eae2). I used the regular `td.double()` and `td.replace()`. 

When I ran `npm test` with nodejs v6.x, it was great! The test passes. The trouble began when I pushed to Github for travis-ci to run ([failed job is here](https://www.travis-ci.org/noopkat/oled-js/builds/244303627)). On nodejs versions 4 and 5, it throws a mysterious error:

<details>
<summary>click to expand error output</summary>

```
> oled-js@4.0.3 test /Users/noopkat/code/oled-js
> node tests/unit/oledjs.spec.js | tap-spec

/Users/noopkat/code/oled-js/node_modules/testdouble/lib/share/copy-props.js:17
    acc[name] = {
              ^

TypeError: Cannot assign to read only property 'includes' of [object Array]
    at /Users/noopkat/code/oled-js/node_modules/testdouble/lib/share/copy-props.js:17:15
    at /Users/noopkat/code/oled-js/node_modules/testdouble/node_modules/lodash/transform.js:60:12
    at arrayEach (/Users/noopkat/code/oled-js/node_modules/testdouble/node_modules/lodash/_arrayEach.js:15:9)
    at Object.transform (/Users/noopkat/code/oled-js/node_modules/testdouble/node_modules/lodash/transform.js:59:39)
    at exports.default (/Users/noopkat/code/oled-js/node_modules/testdouble/lib/share/copy-props.js:14:52)
    at /Users/noopkat/code/oled-js/node_modules/testdouble/lib/constructor.js:49:29
    at Object.tap (/Users/noopkat/code/oled-js/node_modules/testdouble/node_modules/lodash/tap.js:25:3)
    at fakeConstructorFromType (/Users/noopkat/code/oled-js/node_modules/testdouble/lib/constructor.js:44:31)
    at exports.default (/Users/noopkat/code/oled-js/node_modules/testdouble/lib/constructor.js:40:57)
    at /Users/noopkat/code/oled-js/node_modules/testdouble/lib/object.js:68:93


npm ERR! Test failed.  See above for more details.

```

</details>
  ---

I installed nodejs 4 locally, and sure enough got the same error when I ran my test.

This is very curious, as the exact prop being replaced when the error threw was a special property used for js primitives - `includes`. So I'm either using testdouble wrong, or for whatever reason these props are being funny in node 4 & 5. When I output the descriptor, it had `writeable` set to `true` for the prop coming from `acc` which I do not understand at all given it hiccuped?

I have made an attempt at a fix within `src/share/copy-props.js`. This pull request may be a somewhat naive way of fixing the problem, but as I'm a first time contributor I wanted to show the initiative to get the conversation started a little easier 🙇‍♀️ 

Let me know what you think if you have some time, and thank you so much for this library. I rather enjoy using it so far 💯 
