### PR TITLE
Upgrade lodash (and support async functions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "es6-map": "^0.1.5",
-    "lodash": "^4.15.0",
+    "lodash": "^4.17.4",
     "quibble": "^0.5.1",
     "resolve": "^1.3.3",
     "stringify-object-es5": "^2.5.0"


### PR DESCRIPTION
lodash@4.17.0 added support for async functions to `_.isFunction`, which allows testdouble.js to properly detect (mockable) functions on objects.

I believe this should fix #284.