### PR TITLE
Ensure captors only fire when invocation satisfies when/verify

### DIFF
--- a/docs/8-custom-matchers.md
+++ b/docs/8-custom-matchers.md
@@ -13,7 +13,7 @@ messages from `td.explain` calls and `td.verify` failures.
 
 (For the record, arguments without a `__matches` property will only match an
 actual invocation if it passes lodash's deep
-[_.isEqual](https://lodash.com/docs#isEqual) test.)
+[`_.isEqual`](https://lodash.com/docs#isEqual) test.)
 
 The examples in this document assume you've aliased `testdouble` to `td`.
 
@@ -49,18 +49,25 @@ datePicker(5) // undefined
 The `create` function takes a configuration object with the following properties
 
 * **matches(matcherArgs, actual)** - _required_ - a function that returns truthy
-when an `actual` argument satisfies the matcher's rules, given what the user
-passed to the matcher as `matcherArgs` when setting it up. For instance, if
-`td.when(func(isFooBar('foo','bar')).thenReturn('baz')` is configured, then
-`func('biz')` is invoked, then `isFooBar`'s `matches` function will be invoked
-with `matcherArgs` of `['foo','bar']` and `actual` of `'biz'`
-* **name** - _optional_ - a string name for better messages. A function can
-also be provided, which will be passed the user's `matcherArgs` and should return
-a string name
+  when an `actual` argument satisfies the matcher's rules, given what the user
+  passed to the matcher as `matcherArgs` when setting it up. For instance, if
+  `td.when(func(isFooBar('foo','bar')).thenReturn('baz')` is configured, then
+  `func('biz')` is invoked, then `isFooBar`'s `matches` function will be invoked
+  with `matcherArgs` of `['foo','bar']` and `actual` of `'biz'`
+* **name** - _optional_ - a string name for better messages. A function can also
+  be provided, which will be passed the user's `matcherArgs` and should return a
+  string name
 * **onCreate(matcherInstance, matcherArgs)** - _optional_ - a function invoked
-whenever an instance of a matcher is created to give the matcher author an
-opportunity to mutate the matcher instance or have some other side effect. The
-`td.callback` functionality of the library depends on this option
+  whenever an instance of a matcher is created to give the matcher author an
+  opportunity to mutate the matcher instance or have some other side effect. The
+  `td.callback` functionality of the library depends on this option
+* **afterSatisfaction(matcherArgs, actual)** - _optional_ - a function invoked
+  whenever `td.when` is satisfied (e.g. all arguments of an invocation match the
+  arguments & matchers of the stubbing) or `td.verify` is satisfied (e.g. one or
+  more invocations match the given arguments & matchers). This is useful when a
+  matcher's behavior depends on whether actual invocations matched the test's
+  expectations (as is the case with [argument
+  captors](6-verifying-invocations.md#multi-phase-assertions-with-argument-captors))
 
 For some examples of `td.matchers.create()` in action, check out the
 [built-in matchers](src/matchers/index.coffee) provided by testdouble.js.

--- a/regression/src/captor-test.coffee
+++ b/regression/src/captor-test.coffee
@@ -8,6 +8,17 @@ describe 'argument captors (a special sub-type of matchers)', ->
     Then -> @captor.value == "PANTS!"
     And -> @stubbing == 'foobaby'
 
+  describe 'when stubbing and other matchers do match', ->
+    Given -> td.when(@testDouble(@captor.capture(), 'PANTS!')).thenReturn('barbaby')
+    When -> @stubbing = @testDouble('SHIRTS!', 'PANTS!')
+    Then -> @captor.value == 'SHIRTS!'
+    And -> @stubbing == 'barbaby'
+
+  describe 'when stubbing and other matchers do not match', ->
+    Given -> td.when(@testDouble(@captor.capture(), 'PANTS!')).thenReturn('barbaby')
+    When -> @stubbing = @testDouble('SHIRTS!', 'HATS!')
+    Then -> @captor.value == undefined
+
   describe 'when verifying', ->
     Given -> @testDouble("SHIRTS!")
     When -> td.verify(@testDouble(@captor.capture()))

--- a/src/matchers/builtin/captor.js
+++ b/src/matchers/builtin/captor.js
@@ -5,10 +5,12 @@ export default () => {
     capture: create({
       name: 'captor.capture',
       matches (matcherArgs, actual) {
+        return true
+      },
+      afterSatisfaction (matcherArgs, actual) {
         captor.values = captor.values || []
         captor.values.push(actual)
         captor.value = actual
-        return true
       }
     })
   }

--- a/src/matchers/create.js
+++ b/src/matchers/create.js
@@ -8,9 +8,12 @@ export default config =>
       __matches (actualArg) {
         return config.matches(matcherArgs, actualArg)
       }
-    }, (matcherInstance) =>
+    }, (matcherInstance) => {
+      matcherInstance.__matches.afterSatisfaction = (actualArg) => {
+        _.invoke(config, 'afterSatisfaction', matcherArgs, actualArg)
+      }
       _.invoke(config, 'onCreate', matcherInstance, matcherArgs)
-    )
+    })
 
 var nameFor = (config, matcherArgs) => {
   if (_.isFunction(config.name)) {

--- a/src/matchers/notify-after-satisfaction.js
+++ b/src/matchers/notify-after-satisfaction.js
@@ -1,0 +1,10 @@
+import _ from '../wrap/lodash'
+import isMatcher from './is-matcher'
+
+export default function notifyAfterSatisfaction (expectedArgs, actualArgs) {
+  _.each(expectedArgs, (expectedArg, i) => {
+    if (isMatcher(expectedArg)) {
+      _.invoke(expectedArg, '__matches.afterSatisfaction', actualArgs[i])
+    }
+  })
+}

--- a/src/matchers/notify-after-satisfaction.js
+++ b/src/matchers/notify-after-satisfaction.js
@@ -1,6 +1,7 @@
 import _ from '../wrap/lodash'
 import isMatcher from './is-matcher'
 
+// TODO: after rewrite, update signature to take (Stubbing/Verification, Call)
 export default function notifyAfterSatisfaction (expectedArgs, actualArgs) {
   _.each(expectedArgs, (expectedArg, i) => {
     if (isMatcher(expectedArg)) {

--- a/src/satisfy/index.js
+++ b/src/satisfy/index.js
@@ -1,5 +1,6 @@
 import findLastStubbingMatch from './find-last-stubbing-match'
 import invokeCallbacks from './invoke-callbacks'
+import notifyAfterSatisfaction from '../matchers/notify-after-satisfaction'
 import deliverOutcome from './deliver-outcome'
 
 export default function satisfy (double, call) {
@@ -7,6 +8,7 @@ export default function satisfy (double, call) {
   if (stubbing) {
     stubbing.addSatisfyingCall(call)
     invokeCallbacks(stubbing, call)
+    notifyAfterSatisfaction(stubbing.args, call.args)
     return deliverOutcome(stubbing, call)
   }
 }

--- a/src/store/stubbings.js
+++ b/src/store/stubbings.js
@@ -1,7 +1,7 @@
 import _ from '../wrap/lodash'
 import argsMatch from '../args-match'
 import isCallback from '../matchers/is-callback'
-import isMatcher from '../matchers/is-matcher'
+import notifyAfterSatisfaction from '../matchers/notify-after-satisfaction'
 import config from '../config'
 import log from '../log'
 import store from './index'
@@ -19,12 +19,7 @@ export default {
   invoke (testDouble, actualArgs, actualContext) {
     const stubbing = stubbingFor(testDouble, actualArgs)
     if (stubbing) {
-      _.each(stubbing.args, (expectedArg, i) => {
-        if (isMatcher(expectedArg)) {
-          _.invoke(expectedArg, '__matches.afterSatisfaction', actualArgs[i])
-        }
-      })
-
+      notifyAfterSatisfaction(stubbing.args, actualArgs)
       return executePlan(stubbing, actualArgs, actualContext)
     }
   },

--- a/src/store/stubbings.js
+++ b/src/store/stubbings.js
@@ -1,6 +1,7 @@
 import _ from '../wrap/lodash'
 import argsMatch from '../args-match'
 import isCallback from '../matchers/is-callback'
+import isMatcher from '../matchers/is-matcher'
 import config from '../config'
 import log from '../log'
 import store from './index'
@@ -18,6 +19,12 @@ export default {
   invoke (testDouble, actualArgs, actualContext) {
     const stubbing = stubbingFor(testDouble, actualArgs)
     if (stubbing) {
+      _.each(stubbing.args, (expectedArg, i) => {
+        if (isMatcher(expectedArg)) {
+          _.invoke(expectedArg, '__matches.afterSatisfaction', actualArgs[i])
+        }
+      })
+
       return executePlan(stubbing, actualArgs, actualContext)
     }
   },

--- a/src/verify.js
+++ b/src/verify.js
@@ -5,12 +5,14 @@ import log from './log'
 import store from './store'
 import stringifyArgs from './stringify/arguments'
 import stubbingsStore from './store/stubbings'
+import isMatcher from './matchers/is-matcher'
 
 export default (__userDoesRehearsalInvocationHere__, config = {}) => {
   const last = callsStore.pop()
   ensureRehearsalOccurred(last)
   if (callsStore.wasInvoked(last.testDouble, last.args, config)) {
     // Do nothing! We're verified! :-D
+    notifyMatchers(last.testDouble, last.args, config)
     warnIfStubbed(last.testDouble, last.args)
   } else {
     log.fail(unsatisfiedErrorMessage(last.testDouble, last.args, config))
@@ -26,6 +28,16 @@ No test double invocation detected for \`verify()\`.
     verify(myTestDouble('foo'))\
 `)
   }
+}
+
+const notifyMatchers = (testDouble, expectedArgs, config) => {
+  _.each(callsStore.where(testDouble, expectedArgs, config), (invocation) => {
+    _.each(expectedArgs, (expectedArg, i) => {
+      if (isMatcher(expectedArg)) {
+        _.invoke(expectedArg, '__matches.afterSatisfaction', invocation.args[i])
+      }
+    })
+  })
 }
 
 var warnIfStubbed = (testDouble, actualArgs) => {

--- a/src/verify.js
+++ b/src/verify.js
@@ -5,13 +5,12 @@ import log from './log'
 import store from './store'
 import stringifyArgs from './stringify/arguments'
 import stubbingsStore from './store/stubbings'
-import isMatcher from './matchers/is-matcher'
+import notifyAfterSatisfaction from './matchers/notify-after-satisfaction'
 
 export default (__userDoesRehearsalInvocationHere__, config = {}) => {
   const last = callsStore.pop()
   ensureRehearsalOccurred(last)
   if (callsStore.wasInvoked(last.testDouble, last.args, config)) {
-    // Do nothing! We're verified! :-D
     notifyMatchers(last.testDouble, last.args, config)
     warnIfStubbed(last.testDouble, last.args)
   } else {
@@ -32,11 +31,7 @@ No test double invocation detected for \`verify()\`.
 
 const notifyMatchers = (testDouble, expectedArgs, config) => {
   _.each(callsStore.where(testDouble, expectedArgs, config), (invocation) => {
-    _.each(expectedArgs, (expectedArg, i) => {
-      if (isMatcher(expectedArg)) {
-        _.invoke(expectedArg, '__matches.afterSatisfaction', invocation.args[i])
-      }
-    })
+    notifyAfterSatisfaction(expectedArgs, invocation.args)
   })
 }
 

--- a/test/unit/satisfy/index.test.js
+++ b/test/unit/satisfy/index.test.js
@@ -2,19 +2,20 @@ import Double from '../../../src/value/double'
 import Call from '../../../src/value/call'
 import Stubbing from '../../../src/value/stubbing'
 
-let findLastStubbingMatch, invokeCallbacks, deliverOutcome, subject
+let findLastStubbingMatch, invokeCallbacks, notifyAfterSatisfaction, deliverOutcome, subject
 module.exports = {
   beforeEach: () => {
     findLastStubbingMatch = td.replace('../../../src/satisfy/find-last-stubbing-match').default
     invokeCallbacks = td.replace('../../../src/satisfy/invoke-callbacks').default
+    notifyAfterSatisfaction = td.replace('../../../src/matchers/notify-after-satisfaction').default
     deliverOutcome = td.replace('../../../src/satisfy/deliver-outcome').default
 
     subject = require('../../../src/satisfy').default
   },
   'finds the last stubbing & returns the executed plan': () => {
     const double = Double.create()
-    const call = new Call()
-    const stubbing = new Stubbing()
+    const call = new Call(null, 'actual args')
+    const stubbing = new Stubbing(null, 'expected args')
     td.when(findLastStubbingMatch(double, call)).thenReturn(stubbing)
     td.when(deliverOutcome(stubbing, call)).thenReturn('huzzah')
 
@@ -23,6 +24,7 @@ module.exports = {
     assert.equal(result, 'huzzah')
     assert.deepEqualSet(stubbing.satisfyingCalls, [call])
     td.verify(invokeCallbacks(stubbing, call))
+    td.verify(notifyAfterSatisfaction(stubbing.args, call.args))
   },
   'does nothing if no matching stubbing found': () => {
     const double = Double.create()
@@ -34,5 +36,6 @@ module.exports = {
     assert.equal(result, undefined)
     assert.equal(td.explain(deliverOutcome).callCount, 0)
     assert.equal(td.explain(invokeCallbacks).callCount, 0)
+    assert.equal(td.explain(notifyAfterSatisfaction).callCount, 0)
   }
 }


### PR DESCRIPTION
@jamestalmage made a good catch in #308 that captors could be used with `td.when` but it was undocumented and it would also capture values when the rest of the rehearsal did not match the actual args. This was effectively a requirements miss, but because our goal is to have `td.when` and `td.verify` to behave as symmetrically as possible, it's something we needed to fix.

James implemented a fix in #310, but I had three quibbles with it: (a) it broadened awareness of "capturing" to matchers themselves, even though captors are a one-off subset, (b) it expanded the private namespace claimed by matchers with `__capture`, and (c) it didn't verify that an argument was a matcher before invoking `__capture`.

- [x] Commit James' failing tests
- [x] implement an `afterSatisfaction` hook to the matcher creation, which only fires after all args match on an invocation or verification
- [x] document the new hook
- [x] make the new behavior work for the in-place rewrite that's still (slowly) underway; right now that means https://github.com/testdouble/testdouble.js/blob/master/src/when/index.js needs to be analyzed and updated with this responsibility

Fixes #310 
Fixes #308