### PR TITLE
allow using matchers inside contains

### DIFF
--- a/regression/src/matchers-test.coffee
+++ b/regression/src/matchers-test.coffee
@@ -94,6 +94,24 @@ describe '.matchers', ->
       Then -> @matches(td.matchers.contains(deep: {thing: 'stuff'}), {}) == false
       Then -> @matches(td.matchers.contains(deep: {thing: 'stuff'}), deep: {thing: 'stuff', shallow: 5}) == true
       Then -> @matches(td.matchers.contains({container: {size: 'S'}}), {ingredient: 'beans', container: { type: 'cup', size: 'S'}}) == true
+      Then -> @matches(td.matchers.contains({someString: td.matchers.isA(String)}), {someString: "beautifulString"}) == true
+      Then -> @matches(
+        td.matchers.contains({someString: td.matchers.isA(String)}),
+        {someString: "beautifulString", irrelevant: true}
+      ) == true
+      Then -> @matches(
+        td.matchers.contains({nested: {someString: td.matchers.isA(String)}, relevant: true}),
+        {nested: {someString: "beautifulString"}, relevant: true}
+      ) == true
+      Then -> @matches(
+        td.matchers.contains({someString: td.matchers.isA(String)}),
+        {someString: 4}
+      ) == false
+      Then -> @matches(
+        td.matchers.contains({nested: td.matchers.contains({nestedString: td.matchers.isA(String)})}),
+        {nested: {nestedString: "abc", irrelevant: true}, irrelevantHere: "alsoTrue"}
+      ) == true
+
 
     context 'regexp', ->
       Then -> @matches(td.matchers.contains(/abc/), 'abc') == true

--- a/src/matchers/builtin/contains.js
+++ b/src/matchers/builtin/contains.js
@@ -20,8 +20,15 @@ export default create({
   }
 })
 
-var containsAllSpecified = (containing, actual) =>
-  actual != null && _.every(containing, (val, key) =>
-    _.isObjectLike(val)
-      ? containsAllSpecified(val, actual[key])
-      : _.isEqual(val, actual[key]))
+var containsAllSpecified = (containing, actual) => {
+  return actual != null && _.every(containing, (val, key) => {
+    if (_.isObjectLike(val)) {
+      if (_.isFunction(val.__matches)) {
+        return val.__matches(actual[key])
+      }
+      return containsAllSpecified(val, actual[key])
+    } else {
+      return _.isEqual(val, actual[key])
+    }
+  })
+}


### PR DESCRIPTION
This allows us to do things like:

```javascript
brew({nested: {nestedString: 'abc', irrelevant: true}, irrelevantHere: 'alsoTrue'})

td.verify(brew(td.matchers.contains({irrelevantHere: td.matchers.isA(String)})))
td.verify(brew(td.matchers.contains(
{nested: td.matchers.contains({nestedString: td.matchers.isA(String)})}
)));
```

Before, the tests I added were failing (basically, you weren't able to mix matcher.contains with other matchers (including another matcher.contains as showed above)