### PR TITLE
replace quibble.browser.js with ES5 version

### DIFF
--- a/src/quibble.browser.js
+++ b/src/quibble.browser.js
@@ -1,5 +1,5 @@
 module.exports = {
-  absolutify () {},
-  ignoreCallsFromThisFile () {},
-  reset () {}
+  absolutify: function absolutify() {},
+  ignoreCallsFromThisFile: function ignoreCallsFromThisFile() {},
+  reset: function reset() {}
 }


### PR DESCRIPTION
- looks like this was pointed to lib originally, but got changed in 45b73bf1
- this caused modules that referenced this ES6 version of the file in src to fail unless they were transpiling quibble.browser.js