### PR TITLE
Avoid implicit any for TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@
 
 export type DoubledObject < T > = T
 
-export type DoubledObjectWithKey < T extends string > = { [K in T] }
+export type DoubledObjectWithKey < T extends string > = { [K in T] : any }
 
 export type TestDouble < T > = T
 


### PR DESCRIPTION
With TypeScript 2.7.1/2.7.2 (node 8.9.4, node 5.6.0), the `tsc` is failing on me with the existing definition. This patch fixes it for me and avoids requiring the `noImplicitAny` flag from being set. 

Maybe there's a better way? This seems like the simplest thing that will work.