### PR TITLE
Test results and caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ defaults: &defaults
   - checkout
   - run: npm install tap-junit
   - run: npm install
-  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results
+  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit.xml
   - run: npm run cover:ci
   - store_artifacts:
       path: test_results
       prefix: test_results
   - store_test_results:
-      path: test_results/tap.xml
+      path: test_results
   - store_artifacts:
       path: coverage
       prefix: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,3 @@
-defaults: &defaults
-  - checkout
-  - run: npm install tap-junit
-  - run: npm install
-  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
-  - run: npm run cover:ci
-  - store_artifacts:
-      path: test_results
-      prefix: test_results
-  - store_test_results:
-      path: test_results
-  - store_artifacts:
-      path: coverage
-      prefix: coverage
-
 version: 2.0
 jobs:
   "node-4":
@@ -20,20 +5,58 @@ jobs:
       - image: circleci/node:4-browsers
     environment:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
-    steps: *defaults
+    steps:
+      - checkout
+      - run: npm install tap-junit
+      - run: npm install
+      - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
+      - run: npm run cover:ci
+      - store_artifacts:
+          path: test_results
+          prefix: test_results
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: coverage
+          prefix: coverage
   "node-6":
     docker:
       - image: circleci/node:6-browsers
     environment:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
-    steps: *defaults
+    steps:
+      - checkout
+      - run: npm install tap-junit
+      - run: npm install
+      - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
+      - run: npm run cover:ci
+      - store_artifacts:
+          path: test_results
+          prefix: test_results
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: coverage
+          prefix: coverage
   "node-8":
     docker:
       - image: circleci/node:8-browsers
     environment:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
-    steps: *defaults
-
+    steps:
+      - checkout
+      - run: npm install tap-junit
+      - run: npm install
+      - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
+      - run: npm run cover:ci
+      - store_artifacts:
+          path: test_results
+          prefix: test_results
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: coverage
+          prefix: coverage
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
     steps:
       - checkout
-      - run: npm install tap-junit
+      - run: npm install tap-junit@1.1.0
       - run: npm install
       - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
       - run: npm run cover:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,21 @@ jobs:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - dependency-cache-v4-{{ checksum "package.json" }}
+            - dependency-cache-v4-
       - run: npm install
+      - save_cache:
+          key: dependency-cache-v4-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+            - examples/babel/node_modules
+            - examples/jest/node_modules
+            - examples/jest-broken/node_modules
+            - examples/plain-html/node_modules
+            - examples/node/node_modules
+            - examples/webpack/node_modules
       - run: npm run test:ci
       - run: npm run cover:ci
       - store_artifacts:
@@ -20,8 +34,22 @@ jobs:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - dependency-cache-v6-{{ checksum "package.json" }}
+            - dependency-cache-v6-
       - run: npm install tap-junit
       - run: npm install
+      - save_cache:
+          key: dependency-cache-v6-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+            - examples/babel/node_modules
+            - examples/jest/node_modules
+            - examples/jest-broken/node_modules
+            - examples/plain-html/node_modules
+            - examples/node/node_modules
+            - examples/webpack/node_modules
       - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
       - run: npm run cover:ci
       - store_artifacts:
@@ -39,8 +67,22 @@ jobs:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - dependency-cache-v8-{{ checksum "package.json" }}
+            - dependency-cache-v8-
       - run: npm install tap-junit
       - run: npm install
+      - save_cache:
+          key: dependency-cache-v8-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+            - examples/babel/node_modules
+            - examples/jest/node_modules
+            - examples/jest-broken/node_modules
+            - examples/plain-html/node_modules
+            - examples/node/node_modules
+            - examples/webpack/node_modules
       - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
       - run: npm run cover:ci
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,8 @@ version: 2.0
 
 default_steps: &default_steps
   - checkout
-  - restore_cache:
-      keys:
-        - dependency-cache-v6-{{ checksum "package.json" }}
-        - dependency-cache-v6-
   - run: npm install tap-junit
   - run: npm install
-  - save_cache:
-      key: dependency-cache-v6-{{ checksum "package.json" }}
-      paths:
-        - ./node_modules
-        - examples/babel/node_modules
-        - examples/jest/node_modules
-        - examples/jest-broken/node_modules
-        - examples/plain-html/node_modules
-        - examples/node/node_modules
-        - examples/webpack/node_modules
   - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
   - run: npm run cover:ci
   - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ default_steps: &default_steps
   - checkout
   - run: npm install tap-junit
   - run: npm install
-  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
+  - run: npm run test:ci
+  - run: npm run test | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
   - run: npm run cover:ci
   - store_artifacts:
       path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,9 @@ jobs:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
     steps:
       - checkout
-      - run: npm install tap-junit@1.0.3
       - run: npm install
-      - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
+      - run: npm run test:ci
       - run: npm run cover:ci
-      - store_artifacts:
-          path: test_results
-          prefix: test_results
-      - store_test_results:
-          path: test_results
       - store_artifacts:
           path: coverage
           prefix: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
     steps:
       - checkout
-      - run: npm install tap-junit@1.1.0
+      - run: npm install tap-junit@1.0.3
       - run: npm install
       - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
       - run: npm run cover:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,71 +1,49 @@
 version: 2.0
+
+default_steps: &default_steps
+  - checkout
+  - restore_cache:
+      keys:
+        - dependency-cache-v6-{{ checksum "package.json" }}
+        - dependency-cache-v6-
+  - run: npm install tap-junit
+  - run: npm install
+  - save_cache:
+      key: dependency-cache-v6-{{ checksum "package.json" }}
+      paths:
+        - ./node_modules
+        - examples/babel/node_modules
+        - examples/jest/node_modules
+        - examples/jest-broken/node_modules
+        - examples/plain-html/node_modules
+        - examples/node/node_modules
+        - examples/webpack/node_modules
+  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
+  - run: npm run cover:ci
+  - store_artifacts:
+      path: test_results
+      prefix: test_results
+  - store_test_results:
+      path: test_results
+  - store_artifacts:
+      path: coverage
+      prefix: coverage
+
+default_env: &default_env
+  - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
+
 jobs:
   "node-6":
     docker:
       - image: circleci/node:6-browsers
-    environment:
-      - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - dependency-cache-v6-{{ checksum "package.json" }}
-            - dependency-cache-v6-
-      - run: npm install tap-junit
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-v6-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
-            - examples/babel/node_modules
-            - examples/jest/node_modules
-            - examples/jest-broken/node_modules
-            - examples/plain-html/node_modules
-            - examples/node/node_modules
-            - examples/webpack/node_modules
-      - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
-      - run: npm run cover:ci
-      - store_artifacts:
-          path: test_results
-          prefix: test_results
-      - store_test_results:
-          path: test_results
-      - store_artifacts:
-          path: coverage
-          prefix: coverage
+    environment: *default_env
+    steps: *default_steps
   "node-8":
     docker:
       - image: circleci/node:8-browsers
-    environment:
-      - CODECLIMATE_REPO_TOKEN: c92188dcdeaca7d9732f8ea38fdd41d6bff18dc27a8d6f8b64a5b1311b7b6c21
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - dependency-cache-v8-{{ checksum "package.json" }}
-            - dependency-cache-v8-
-      - run: npm install tap-junit
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-v8-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
-            - examples/babel/node_modules
-            - examples/jest/node_modules
-            - examples/jest-broken/node_modules
-            - examples/plain-html/node_modules
-            - examples/node/node_modules
-            - examples/webpack/node_modules
-      - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
-      - run: npm run cover:ci
-      - store_artifacts:
-          path: test_results
-          prefix: test_results
-      - store_test_results:
-          path: test_results
-      - store_artifacts:
-          path: coverage
-          prefix: coverage
+    environment: *default_env
+    steps: *default_steps
+
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,14 @@
 defaults: &defaults
   - checkout
+  - run: npm install tap-junit
   - run: npm install
-  - run: npm run test:ci
+  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results
   - run: npm run cover:ci
+  - store_artifacts:
+      path: test_results
+      prefix: test_results
+  - store_test_results:
+      path: test_results/tap.xml
   - store_artifacts:
       path: coverage
       prefix: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ defaults: &defaults
   - checkout
   - run: npm install tap-junit
   - run: npm install
-  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit.xml
+  - run: npm run test:ci | ./node_modules/tap-junit/bin/tap-junit --output test_results --name junit
   - run: npm run cover:ci
   - store_artifacts:
       path: test_results


### PR DESCRIPTION
I've re-enabled caching and setup test summary support in the build UI.

Some builds for node version 8:

* [no cache, pre cache commit: **1:30s**](https://circleci.com/gh/zzak/testdouble.js/60)
* [no cache, cache enabled **1:53s**](https://circleci.com/gh/zzak/testdouble.js/63)
* [cached **1:22s**](https://circleci.com/gh/zzak/testdouble.js/68)

However, note the time is actually unaffected by cache, and each `npm install` step takes about ~9-10 seconds either way. I wonder why?

In any case, this is how you'd set up caching so feel free to adjust, or remove it (there's a penalty for uncached builds as you can see 8 seconds added for uploading them in [this build](https://circleci.com/gh/zzak/testdouble.js/63).

Also, does the test summary look accurate? 

`Your build ran 317 tests in unknown with 0 failures`

I'm not familiar with your suite so it may be missing some examples. Let me know.

Thanks!