### PR TITLE
Export td.quibble

### DIFF
--- a/examples/jest-broken/package-lock.json
+++ b/examples/jest-broken/package-lock.json
@@ -4044,7 +4044,7 @@
       }
     },
     "testdouble-jest": {
-      "version": "github:testdouble/testdouble-jest#25aa8ceee57511d7433b37d5e5e9be9be130a5de",
+      "version": "github:testdouble/testdouble-jest#e7ecc759d0aaeef6b7f007926ac1b7c261dbaab5",
       "dev": true
     },
     "throat": {

--- a/examples/jest-broken/package.json
+++ b/examples/jest-broken/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "jest": "^22.2.2",
-    "testdouble-jest": "testdouble/testdouble-jest"
+    "testdouble-jest": "github:testdouble/testdouble-jest"
   }
 }

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -13,6 +13,6 @@
     "testdouble-jest": "testdouble/testdouble-jest"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./helper.js"
+    "setupTestFrameworkScriptFile": "./support/helper.js"
   }
 }

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "jest": "^22.2.2",
-    "testdouble-jest": "testdouble/testdouble-jest"
+    "testdouble-jest": "github:testdouble/testdouble-jest"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "./support/helper.js"

--- a/examples/jest/support/helper.js
+++ b/examples/jest/support/helper.js
@@ -1,4 +1,4 @@
-global.td = require('../..')
+global.td = require('../../..')
 global.expect = require('expect')
 
 require('testdouble-jest')(td, jest)

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import reset from './reset'
 import config from './config'
 import callback from './callback'
 import version from './version'
+import * as quibble from 'quibble'
 
 module.exports = {
   function: tdFunction,
@@ -26,5 +27,6 @@ module.exports = {
   reset,
   config,
   callback,
-  version
+  version,
+  quibble
 }

--- a/src/replace/jest-module.js
+++ b/src/replace/jest-module.js
@@ -1,4 +1,7 @@
+import * as quibble from 'quibble'
 import log from '../log'
+
+quibble.ignoreCallsFromThisFile()
 
 export default function jestModule (path, stub) {
   const tdMock = require('../index').mock

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -17,6 +17,7 @@ module.exports = () => {
   const reset = td.replace('../../src/reset').default
   const config = td.replace('../../src/config').default
   const version = td.replace('../../src/version').default
+  const quibble = td.replace('quibble')
 
   const subject = require('../../src')
 
@@ -34,6 +35,7 @@ module.exports = () => {
     explain: explain,
     reset: reset,
     config: config,
-    version: version
+    version: version,
+    quibble
   })
 }


### PR DESCRIPTION
This is not my favorite thing to do, but b/c quibble is stateful
and some extensions will need its absolutify() function (since
testdouble-jest and others are basically just meta test helpers)
that means they'll need the ability to call 
quibble.ignoreCallsToThisFile.

This probably will never be needed by end users but might come in handy.
¯\_(ツ)_/¯

I'd warn users to consider this private & undocumented, though unlikely to break