### PR TITLE
Enhance contains for edge cases, make nesting behave consistently

### DIFF
--- a/script/repl
+++ b/script/repl
@@ -5,7 +5,7 @@ var repl = require('repl')
 
 console.log('💚  Let\'s play with testdouble.js!  💚')
 global.td = require('../src')
-global._ = require('lodash')
+global.l = require('lodash')
 repl.start({prompt: 'td > ', useGlobal: true})
 
 

--- a/src/matchers/builtin/contains.js
+++ b/src/matchers/builtin/contains.js
@@ -20,6 +20,9 @@ const argumentContains = function (containing, actualArg) {
     return containing.test(actualArg)
   } else if (isMatcher(containing)) {
     return _.some(actualArg, containing.__matches)
+  } else if (containing instanceof Error) {
+    return actualArg instanceof Error &&
+      _.includes(actualArg.message, containing.message)
   } else if (_.isObjectLike(containing) && _.isObjectLike(actualArg)) {
     return containsPartialObject(containing, actualArg)
   } else {

--- a/src/matchers/builtin/contains.js
+++ b/src/matchers/builtin/contains.js
@@ -17,7 +17,11 @@ const argumentContains = function (containing, actualArg) {
   if (_.isArray(containing)) {
     return _.some(actualArg, actualElement => _.isEqual(actualElement, containing))
   } else if (_.isRegExp(containing)) {
-    return containing.test(actualArg)
+    if (_.isString(actualArg)) {
+      return containing.test(actualArg)
+    } else if (_.isRegExp(actualArg)) {
+      return containing.toString() === actualArg.toString()
+    }
   } else if (isMatcher(containing)) {
     return _.some(actualArg, containing.__matches)
   } else if (containing instanceof Date) {

--- a/src/matchers/builtin/contains.js
+++ b/src/matchers/builtin/contains.js
@@ -20,6 +20,9 @@ const argumentContains = function (containing, actualArg) {
     return containing.test(actualArg)
   } else if (isMatcher(containing)) {
     return _.some(actualArg, containing.__matches)
+  } else if (containing instanceof Date) {
+    return actualArg instanceof Date &&
+      containing.getTime() === actualArg.getTime()
   } else if (containing instanceof Error) {
     return actualArg instanceof Error &&
       _.includes(actualArg.message, containing.message)

--- a/test/safe/matchers.test.js
+++ b/test/safe/matchers.test.js
@@ -263,6 +263,11 @@ module.exports = {
         a: [5]
       })
     },
+    'errors' () {
+      matches(td.matchers.contains(new Error('eek')), new Error('eek'))
+      matches(td.matchers.contains(new Error('message')), new Error('long message'))
+      doesntMatch(td.matchers.contains(new Error('eek')), new Error('woah'))
+    },
     'regexp' () {
       matches(td.matchers.contains(/abc/), 'abc')
       doesntMatch(td.matchers.contains(/abc/), {

--- a/test/safe/matchers.test.js
+++ b/test/safe/matchers.test.js
@@ -121,6 +121,24 @@ module.exports = {
       doesntMatch(td.matchers.contains(true, 5, null, void 0), [true, 5, null])
       matches(td.matchers.contains('b', td.matchers.isA(Number)), ['a', 3, 'b'])
     },
+    'dates' () {
+      matches(td.matchers.contains(new Date('2011')), new Date('2011'))
+      doesntMatch(td.matchers.contains(new Date('2011')), new Date('2012'))
+    },
+    'errors' () {
+      matches(td.matchers.contains(new Error('eek')), new Error('eek'))
+      matches(td.matchers.contains(new Error('message')), new Error('long message'))
+      doesntMatch(td.matchers.contains(new Error('eek')), new Error('woah'))
+    },
+    'regexp' () {
+      matches(td.matchers.contains(/abc/), 'abc')
+      matches(td.matchers.contains(/abc/), /abc/)
+      doesntMatch(td.matchers.contains(/abc/), /abcd/)
+      doesntMatch(td.matchers.contains(/abc/), {
+        foo: 'bar'
+      })
+      doesntMatch(td.matchers.contains(/abc/), ['foo', 'bar'])
+    },
     'objects' () {
       matches(td.matchers.contains({
         foo: 'bar',
@@ -263,26 +281,25 @@ module.exports = {
         a: [5]
       })
     },
-    'dates' () {
-      matches(td.matchers.contains(new Date('2011')), new Date('2011'))
-      doesntMatch(td.matchers.contains(new Date('2011')), new Date('2012'))
-    },
-    'errors' () {
-      matches(td.matchers.contains(new Error('eek')), new Error('eek'))
-      matches(td.matchers.contains(new Error('message')), new Error('long message'))
-      doesntMatch(td.matchers.contains(new Error('eek')), new Error('woah'))
-    },
-    'regexp' () {
-      matches(td.matchers.contains(/abc/), 'abc')
-      matches(td.matchers.contains(/abc/), /abc/)
-      doesntMatch(td.matchers.contains(/abc/), /abcd/)
-      doesntMatch(td.matchers.contains(/abc/), {
-        foo: 'bar'
-      })
-      doesntMatch(td.matchers.contains(/abc/), ['foo', 'bar'])
+    'objects with nested edge cases' () {
+      matches(td.matchers.contains({d: new Date('1999')}), {d: new Date('1999')})
+      doesntMatch(td.matchers.contains({d: new Date('1999')}), {d: new Date('2099')})
+
+      matches(td.matchers.contains({e: new Error('ew')}), {e: new Error('eww')})
+      doesntMatch(td.matchers.contains({e: new Error('?')}), {e: new Error('!')})
+
+      matches(td.matchers.contains({r: /abc/}), {r: /abc/})
+      matches(td.matchers.contains({r: /abc/}), {r: 'abc'})
+      doesntMatch(td.matchers.contains({r: /abc/}), {r: /abcd/})
     },
     'nonsense' () {
-      doesntMatch(td.matchers.contains(42), 42)
+      // These are a bit stupid, but necessary to support deep comparisons
+      matches(td.matchers.contains(42), 42)
+      matches(td.matchers.contains(td.matchers.isA(Number)), 42)
+
+      // These definitely should not match
+      doesntMatch(td.matchers.contains(43), 42)
+      doesntMatch(td.matchers.contains(td.matchers.isA(String)), 42)
       doesntMatch(td.matchers.contains(null), 'shoo')
       doesntMatch(td.matchers.contains(), 'shoo')
       doesntMatch(td.matchers.contains({}), void 0)

--- a/test/safe/matchers.test.js
+++ b/test/safe/matchers.test.js
@@ -274,6 +274,8 @@ module.exports = {
     },
     'regexp' () {
       matches(td.matchers.contains(/abc/), 'abc')
+      matches(td.matchers.contains(/abc/), /abc/)
+      doesntMatch(td.matchers.contains(/abc/), /abcd/)
       doesntMatch(td.matchers.contains(/abc/), {
         foo: 'bar'
       })

--- a/test/safe/matchers.test.js
+++ b/test/safe/matchers.test.js
@@ -263,6 +263,10 @@ module.exports = {
         a: [5]
       })
     },
+    'dates' () {
+      matches(td.matchers.contains(new Date('2011')), new Date('2011'))
+      doesntMatch(td.matchers.contains(new Date('2011')), new Date('2012'))
+    },
     'errors' () {
       matches(td.matchers.contains(new Error('eek')), new Error('eek'))
       matches(td.matchers.contains(new Error('message')), new Error('long message'))


### PR DESCRIPTION

Previously the comparison logic for traversable JS objects was separate
(presumably to avoid cycles, but possibly also because it was a
partial equality check, whereas the top-level contains() routine was a
case-by-case assessment of whether something contained something else.
This leads to confusing edge cases where something considered
"contained" when inside a {} property would not be considered contained
when passed to the top-level matcher. Whatever benefit this might have
conferred was surely more confusing than it was worth.

This only really required a change to one existing test-case, that is
when whatever is passed to contains() happens to deeply equal whatever
is actually passed, but that was never really a supported requirement,
so I'm wary of judging this a breaking change, since intuitively it
makes sense that the two things are in agreement. It could, however,
throw some folks off when they're testing that something wraps something
else in an additional array (in which case this would generate a false
positive), though, and I don't have a good answer for that other than
it's hard to divine someone's intent given how incredibly permissive
this function's parameter signature is.

Fixes #358