### PR TITLE
Add onReset hook.

### DIFF
--- a/src/reset.js
+++ b/src/reset.js
@@ -2,15 +2,21 @@ import _ from './wrap/lodash'
 import * as quibble from 'quibble'
 import store from './store'
 
-let resetHandlers = []
+let onResetHandlers = []
+let onNextResetHandlers = []
 
 export default _.tap(() => {
   store.reset()
   quibble.reset()
-  _.each(resetHandlers, (resetHandler) =>
+  _.each(onResetHandlers, (resetHandler) =>
     resetHandler())
-  resetHandlers = []
+  _.each(onNextResetHandlers, (resetHandler) =>
+    resetHandler())
+  onNextResetHandlers = []
 }, (reset) => {
+  reset.onReset = (func) =>
+    onResetHandlers.push(func)
+
   reset.onNextReset = (func) =>
-    resetHandlers.push(func)
+    onNextResetHandlers.push(func)
 })

--- a/test/unit/reset.test.js
+++ b/test/unit/reset.test.js
@@ -1,0 +1,55 @@
+let quibble, store, subject
+module.exports = {
+  beforeEach: () => {
+    quibble = td.replace('quibble')
+    store = td.replace('../../src/store').default
+
+    subject = require('../../src/reset').default
+  },
+  'resetting the store and modules': () => {
+    subject()
+
+    td.verify(store.reset())
+    td.verify(quibble.reset())
+  },
+  'calling onReset on reset': () => {
+    const resetHandler = td.function()
+
+    subject.onReset(() => resetHandler())
+
+    subject()
+
+    td.verify(resetHandler())
+  },
+  'calling onReset after each reset': () => {
+    const resetHandler = td.function()
+
+    subject.onReset(() => resetHandler())
+
+    subject()
+    assert.equal(td.explain(resetHandler).callCount, 1)
+
+    subject()
+    assert.equal(td.explain(resetHandler).callCount, 2)
+  },
+  'calling onNextReset on reset': () => {
+    const resetHandler = td.function()
+
+    subject.onNextReset(() => resetHandler())
+
+    subject()
+
+    td.verify(resetHandler())
+  },
+  'calling onNextReset after each reset': () => {
+    const resetHandler = td.function()
+
+    subject.onNextReset(() => resetHandler())
+
+    subject()
+    assert.equal(td.explain(resetHandler).callCount, 1)
+
+    subject()
+    assert.equal(td.explain(resetHandler).callCount, 1)
+  }
+}


### PR DESCRIPTION
Pursuant to #377, this PR adds support for an `onReset` hook. It also adds a test spec for reset functionality as I noticed one was missing.