### PR TITLE
typeof function for interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -254,3 +254,5 @@ export function when(...args: any[]): Stubber;
  * @returns {Stubber}
  */
 export function verify(a: any, check?: VerificationConfig): void;
+
+export function typeOf<T>(): T;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import config from './config'
 import callback from './callback'
 import version from './version'
 import * as quibble from 'quibble'
+import typeOf from './typeOf'
 
 module.exports = {
   function: tdFunction,
@@ -19,6 +20,7 @@ module.exports = {
   object,
   constructor,
   imitate,
+  typeOf,
   when,
   verify,
   matchers,

--- a/src/typeOf/index.js
+++ b/src/typeOf/index.js
@@ -1,0 +1,16 @@
+import func from '../function'
+
+export default function typeOf () {
+  const mocks = {}
+
+  const get = property => {
+    if (!mocks[property]) {
+      mocks[property] = func()
+    }
+    return mocks[property]
+  }
+
+  return new Proxy(() => {}, {
+    get: (_, property) => get(property)
+  })
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -7,6 +7,7 @@ module.exports = () => {
   const constructor = td.replace('../../src/constructor').default
   const replace = td.replace('../../src/replace').default
   const imitate = td.replace('../../src/imitate').default
+  const typeOf = td.replace('../../src/typeOf').default
   // Stubbing & Verifying
   const when = td.replace('../../src/when').default
   const verify = td.replace('../../src/verify').default
@@ -28,6 +29,7 @@ module.exports = () => {
     constructor: constructor,
     replace: replace,
     imitate: imitate,
+    typeOf: typeOf,
     when: when,
     verify: verify,
     matchers: matchers,

--- a/test/unit/typeOf/index.test.js
+++ b/test/unit/typeOf/index.test.js
@@ -1,0 +1,26 @@
+let subject
+module.exports = {
+  beforeEach: () => {
+    subject = require('../../../src/typeOf/index').default
+  },
+  'creates a mock on first call': () => {
+    const typeOf = subject()
+
+    typeOf.hello('x')
+
+    td.verify(typeOf.hello('x'), { times: 1 })
+  },
+  'reuses the mock on subsequent calls': () => {
+    const typeOf = subject()
+
+    typeOf.hello('x')
+    typeOf.hello('x')
+
+    // console.log(typeOf.hello)
+    // console.log(td.explain(typeOf.hello))
+    // Above says that it is not a testdouble, even though the console.log above says it IS a testdouble
+    // it all works just fine when I import the code in an external project so I'm a bit stunned
+
+    td.verify(typeOf.hello('x'), { times: 2 })
+  }
+}


### PR DESCRIPTION
As per discussion in #356 

This is the initial work for getting testdouble work with interfaces.
Missing:
[] Working tests
[] Documentation

I'm not sure how to write a nice test for it (we are getting so meta..) - I hope that for someone that knows the codebase better (and what is going on behind the tinyteest setup for tests) it will be obvious what I'm doing wrong. The same code works just fine if I import the linked testdouble and try it in actual tests. But, I'm not even sure if that's the best way to test this - so I didn't want to spend too much time digging around.

To show you how beautiful workflow this allows:

<img width="982" alt="screen shot 2018-12-25 at 9 32 11 am" src="https://user-images.githubusercontent.com/4002543/50414042-753c9a80-082c-11e9-889f-1a99cf786cc2.png">


with all the typescript goodies:

<img width="949" alt="screen shot 2018-12-25 at 9 32 28 am" src="https://user-images.githubusercontent.com/4002543/50414052-82f22000-082c-11e9-8aa4-f8a9bc500132.png">
<img width="1486" alt="screen shot 2018-12-25 at 9 32 16 am" src="https://user-images.githubusercontent.com/4002543/50414053-84234d00-082c-11e9-8473-92e0bba0ec14.png">

If this looks good and we can figure out what to do with tests, I'm happy to write some docs (unless Justin wants to do so - the docs here are very strongly opinionated after all, and go much beyond showing the API) 


I would also like to take the next step here and talk about typing the .thenReturn and thenResolve like here:

<img width="931" alt="screen shot 2018-12-25 at 10 10 45 am" src="https://user-images.githubusercontent.com/4002543/50414158-5d194b00-082d-11e9-9688-9baac53beffe.png">

In real life situation I made this kind of a helper for myself and then I get this help:

<img width="1293" alt="screen shot 2018-12-25 at 10 11 50 am" src="https://user-images.githubusercontent.com/4002543/50414192-8a65f900-082d-11e9-8955-da7fdd4dbb4c.png">

Not only the IDE can catch typos (which could possibly lead to tests passing but app not working in production), but it can also jump to the property definition (the blue dot with red arrow next to the line number).

If this is something that sounds reasonable, I'm happy to create a PR as well.