### PR TITLE
allow for creating testdoubles using interface only

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,6 +167,7 @@ export function object<T extends string>(props: T[]): DoubledObjectWithKey<T>;
  * @returns {DoubledObject<T>}
  */
 export function object<T>(object: string): DoubledObject<T>;
+export function object<T>(): DoubledObject<T>;
 
 /**
  * Create a fake object that is deep copy of the given object.


### PR DESCRIPTION
continuing from #399 
@searls was right, the object function has all the necessary functionality built in. The only thing I had to tweak was this new type that allows for:
```javascript
td.object<IMyInterface>(); 
```
but even with the current code testdouble actually allowed for mocking based on an interface, but with a bit of redundancy:
```javascript
td.object<IMyInterface>("");
````

@wpannell you can use the second one already (with an argument of a string) for your training, with this merged in you will be able to remove the argument for a bit cleaner syntax. 