### PR TITLE
allow for deeply nested test double objects

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -41,14 +41,12 @@ var createTestDoubleViaProxy = (name, config) => {
     if (!target.hasOwnProperty(propKey) && !_.includes(config.excludeMethods, propKey)) {
       let nameWithProp = `${nameOf(internalName)}.${String(propKey)}`
       const obj = tdFunction(nameWithProp)
-      obj.___mocks___ = {}
       target[propKey] = new Proxy(obj, generateHandler(nameWithProp))
     }
     return target[propKey]
   }
 
   const obj = {}
-  obj.___mocks___ = {}
   return new Proxy(obj, generateHandler(name))
 }
 

--- a/src/object.js
+++ b/src/object.js
@@ -32,15 +32,24 @@ var createTestDoublesForFunctionNames = (names) =>
 
 var createTestDoubleViaProxy = (name, config) => {
   ensureProxySupport(name)
-  const obj = {}
-  return new Proxy(obj, {
-    get (target, propKey, receiver) {
-      if (!obj.hasOwnProperty(propKey) && !_.includes(config.excludeMethods, propKey)) {
-        obj[propKey] = tdFunction(`${nameOf(name)}.${String(propKey)}`)
-      }
-      return obj[propKey]
-    }
+
+  const generateHandler = (internalName) => ({
+    get: (target, propKey) => generateGet(target, propKey, internalName)
   })
+
+  const generateGet = (target, propKey, internalName) => {
+    if (!target.hasOwnProperty(propKey) && !_.includes(config.excludeMethods, propKey)) {
+      let nameWithProp = `${nameOf(internalName)}.${String(propKey)}`
+      const obj = tdFunction(nameWithProp)
+      obj.___mocks___ = {}
+      target[propKey] = new Proxy(obj, generateHandler(nameWithProp))
+    }
+    return target[propKey]
+  }
+
+  const obj = {}
+  obj.___mocks___ = {}
+  return new Proxy(obj, generateHandler(name))
 }
 
 var ensureProxySupport = (name) => {

--- a/test/safe/object.test.js
+++ b/test/safe/object.test.js
@@ -124,9 +124,20 @@ module.exports = {
       td.when(testDouble.something()).thenReturn('Original Something')
       td.when(testDouble.different.something()).thenReturn('Different Something')
 
-      testDouble.___mocks___ = {}
       assert._isEqual(testDouble.something(), 'Original Something')
       assert._isEqual(testDouble.different.something(), 'Different Something')
+    },
+    'Resets all deeply nested test doubles with td.reset' () {
+      if (!global.Proxy) return
+      testDouble = td.object()
+
+      td.when(testDouble.something()).thenReturn('Original Something')
+      td.when(testDouble.different.something()).thenReturn('Different Something')
+
+      td.reset()
+
+      assert._isEqual(testDouble.something(), undefined)
+      assert._isEqual(testDouble.different.something(), undefined)
     }
   }
 }

--- a/test/safe/object.test.js
+++ b/test/safe/object.test.js
@@ -107,6 +107,26 @@ module.exports = {
       } catch (e) {
         assert._isEqual(e.message, "Error: testdouble.js - td.object - The current runtime does not have Proxy support, which is what\ntestdouble.js depends on when a string name is passed to `td.object()`.\n\nMore details here:\n  https://github.com/testdouble/testdouble.js/blob/master/docs/4-creating-test-doubles.md#objectobjectname\n\nDid you mean `td.object(['Woah'])`?")
       }
+    },
+    'Allow for deeply nested test double objects' () {
+      if (!global.Proxy) return
+      testDouble = td.object()
+
+      td.when(testDouble.something.very.deeply.nested()).thenReturn('nay!')
+
+      assert._isEqual(testDouble.something.very.deeply.nested(), 'nay!')
+      assert._isEqual(testDouble.something.very.deeply.nested.toString(), '[test double for ".something.very.deeply.nested"]')
+    },
+    'Deeply nested test double objects work also when its property names are repeated' () {
+      if (!global.Proxy) return
+      testDouble = td.object()
+
+      td.when(testDouble.something()).thenReturn('Original Something')
+      td.when(testDouble.different.something()).thenReturn('Different Something')
+
+      testDouble.___mocks___ = {}
+      assert._isEqual(testDouble.something(), 'Original Something')
+      assert._isEqual(testDouble.different.something(), 'Different Something')
     }
   }
 }


### PR DESCRIPTION
Popular Prisma [graphqlgen](https://github.com/prisma/graphqlgen) scaffolds a graphql server with a Context interface, that is used by graphql resolvers to execute commands and queries (on services, repositories, etc).

the default generated example looks like this:
```typescript
export interface Context {
  data: Data
}

export interface User {
  id: string
  name: string | null
  postIDs: string[]
}

export interface Post {
  id: string
  title: string
  content: string
  published: boolean
  authorId: string
}

export interface Data {
  posts: Post[]
  users: User[]
  idProvider: () => string
}

```
With this change I can do things like:

```typescript

const context = td.object<Context>();

context.data.users = [{id: "userId", name: "Hello", postIDs: []}]
td.when(context.data.idProvider()).thenReturn("providerId")
```


And everything is still properly typed. :-) 
Meaning - if I do 
```typescript
context.data.users = [{ids: "userId"}]
```

I get `TS2322: Type '{ ids: string; }' is not assignable to type 'User'.`

and for
```typescript
context.data.users = [{id: "userId", name: "Hello", postIDs: [1]}]
```
I get `TS2322: Type 'number' is not assignable to type 'string'.` error, with the `1` marked in the IDE as an error.

for 
```typescript
   td.when(context.data.idProvider("sdf")).thenReturn("providerId")
```
I get `TS2554: Expected 0 arguments, but got 1.`

...and so on.

This context type that  holds repositories/services is a common graphql pattern. I'm pretty sure there could be other uses as well. 



