### PR TITLE
docs: Correct broken link to testdouble-qunit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ may also want to check out one of these extensions:
 * [testdouble-jest](https://github.com/testdouble/testdouble-jest)
 * [testdouble-chai](https://github.com/basecase/testdouble-chai)
 * [testdouble-jasmine](https://github.com/BrianGenisio/testdouble-jasmine)
-* [testdouble-qunit](http://alexlafroscia.com/testdouble-qunit/latest/docs)
+* [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ may also want to check out one of these extensions:
 * [testdouble-jest](https://github.com/testdouble/testdouble-jest)
 * [testdouble-chai](https://github.com/basecase/testdouble-chai)
 * [testdouble-jasmine](https://github.com/BrianGenisio/testdouble-jasmine)
-* [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit)
+* [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit/tree/master/packages/testdouble-qunit)
 
 ## Getting started
 


### PR DESCRIPTION
Also I find it amazing that this PR is also #404 

/cc @alexlafroscia who might have a new link to the docs