### PR TITLE
Remove unnecessary dependency on es6-map.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -962,6 +962,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.9"
       }
@@ -1223,6 +1224,7 @@
       "version": "0.10.38",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
       "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1"
@@ -1232,6 +1234,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -1242,6 +1245,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14",
@@ -1255,6 +1259,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14",
@@ -1267,6 +1272,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -1632,6 +1638,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -2663,11 +2670,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         }
       }
@@ -2709,6 +2716,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3030,7 +3038,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3114,6 +3123,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3160,7 +3170,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3426,7 +3437,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -4950,7 +4962,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     ]
   },
   "dependencies": {
-    "es6-map": "^0.1.5",
     "lodash": "^4.17.11",
     "quibble": "^0.5.5",
     "stringify-object-es5": "^2.5.0",

--- a/src/imitate/index.js
+++ b/src/imitate/index.js
@@ -1,5 +1,3 @@
-import * as Map from 'es6-map'
-
 import initializeNames from './initialize-names'
 import createImitation from './create-imitation'
 import overwriteChildren from './overwrite-children'

--- a/src/value/call-log.js
+++ b/src/value/call-log.js
@@ -1,5 +1,3 @@
-import * as Map from 'es6-map'
-
 let instance = null
 
 export default class CallLog {

--- a/src/value/stubbing-register.js
+++ b/src/value/stubbing-register.js
@@ -1,5 +1,3 @@
-import * as Map from 'es6-map'
-
 let instance = null
 
 export default class StubbingRegister {


### PR DESCRIPTION
As a follow-up to #367, this PR removes the `es6-map` dependency from `testdouble.js`.