### PR TITLE
[Issue-370] - Update createTestDoublesForFunctionNames to return an object

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -29,7 +29,7 @@ var fakeObject = function (nameOrType, config, argCount) {
 var createTestDoublesForFunctionNames = (names) =>
   _.transform(names, (acc, funcName) => {
     acc[funcName] = tdFunction(`.${String(funcName)}`)
-  })
+  }, {})
 
 var ensureFunctionIsNotPassed = () =>
   log.error('td.object', `Functions are not valid arguments to \`td.object\` (as of testdouble@2.0.0). Please use \`td.function()\` or \`td.constructor()\` instead for creating fake functions.`)

--- a/test/safe/object.test.js
+++ b/test/safe/object.test.js
@@ -29,6 +29,7 @@ module.exports = {
 
     td.when(testDouble.biz()).thenReturn('zing!')
 
+    assert._isEqual(Array.isArray(testDouble), false)
     assert._isEqual(testDouble.biz(), 'zing!')
     assert._isEqual(testDouble.toString(), '[test double object]')
     assert._isEqual(testDouble.bam.toString(), '[test double for ".bam"]')


### PR DESCRIPTION
cc @primarilysnark 

This PR addresses [Issue 370](https://github.com/testdouble/testdouble.js/issues/370).

Context: When `td.object` is called with an array of function names, it returns an array; my understanding of the issue is that `td.object` should always return an object.

From the original issue:

```
> td.object({ something() {} }).splice
undefined
> td.object(['something']).splice
[Function: splice]
```

Included Changes:
- Add an assertion to the `td.object` w/ array of function names test, to confirm that the resulting object is _not_ an array.
- Add a base value of `{}` to the accumulator in `createTestDoublesForFunctionNames`, to ensure that it responds with an object.
