### PR TITLE
Missing TypeScript declaration for td.matchers.create() added

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,13 +32,21 @@ export interface Explanation {
   isTestDouble: boolean;
 }
 
+export interface MatcherConfig {
+  matches(matcherArgs: any[], actual: any): boolean;
+  name?: string | ((matcherArgs: any[]) => string);
+  onCreate?(matcherInstance: any, matcherArgs: any[]): void;
+  afterSatisfaction?(matcherArgs: any[], actual: any): void;
+}
+
 export interface Matchers {
   anything(): any;
   isA(type: Function): any;
   contains(a: string | any[] | {}): any;
   argThat(matcher: Function): any;
   not(v: any): any;
-  captor(): Captor
+  captor(): Captor;
+  create(config: MatcherConfig): any;
 }
 
 export const matchers: Matchers


### PR DESCRIPTION
TypeScript declaration for `td.matchers.create()` has been added according to the API described at https://github.com/testdouble/testdouble.js/blob/master/docs/8-custom-matchers.md#tdmatcherscreate-api.