### PR TITLE
docs: add `testdouble-qunit` to Plugins list

### DIFF
--- a/docs/A-plugins.md
+++ b/docs/A-plugins.md
@@ -23,6 +23,8 @@ Thes plugins developed by ourselves & the community:
 * [testdouble-chai](https://github.com/basecase/testdouble-chai) - Chai assertions
 * [testdouble-jasmine](https://github.com/BrianGenisio/testdouble-jasmine) -
 Jasmine `expect` matchers (by @BrianGenisio)
+* [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit/tree/master/packages/testdouble-qunit) -
+QUnit assertion
 
 ## Build Plugins
 


### PR DESCRIPTION
Adds `testdouble-qunit` to list of plugins that integrate Testdouble with populate test runners