### PR TITLE
Easier on readers when following links

### DIFF
--- a/docs/5-stubbing-results.md
+++ b/docs/5-stubbing-results.md
@@ -95,9 +95,12 @@ As you can see, any additional invocations will continue to return the final stu
 
 #### A note on unconditional stubbing
 
-Note that these stubbings will only return their stubbed value if called exactly as they're demonstrated when `td.when()` is invoked. That means, given the examples above, that invoking things like:
+Note that these stubbings will only return their stubbed value if called exactly as they're demonstrated when `td.when()` is invoked. That means, that invoking things like so:
 
 ``` javascript
+var quack = td.function('quack')
+td.when(quack()).thenReturn('some return value')
+
 quack('hi')
 quack([1,2,3],4)
 quack('anything','at','all')


### PR DESCRIPTION
Heya, 
Newcomer to TD so please, don't mock me 😏
On my journey through the docs I landed [here](https://github.com/testdouble/testdouble.js/blob/master/docs/5-stubbing-results.md#loosening-stubbings-with-argument-matchers) coming from [here](https://github.com/testdouble/testdouble.js#tdwhen-for-stubbing-responses) and found myself confused because the first example above had nothing to do with it. Over the course of making the proposed edit I realized that the original text "examples above" is correct, but it's like three examples (code blocks) ago, and not any of the example invocations in the code block above.
I think this change could help, and even if the reader was coming from the top of the doc, they're just getting a little bit of reinforcement. And we can both agree that appropriately-spaced repetition is the best way to appease the Crabigator.

じゃあね