### PR TITLE
Fix Incorrect Formatting in Docs

### DIFF
--- a/docs/9-debugging.md
+++ b/docs/9-debugging.md
@@ -75,7 +75,7 @@ td.explain(myTestDouble) /*
 */
 ```
 
-You can actually pass anything created by `td.func()`, td.object()`,
+You can actually pass anything created by `td.func()`, `td.object()`,
 `td.constructor()` and `td.imitate()` to `td.explain()` and it will be
 recursively described, with all of the functions found explained in this format.
 


### PR DESCRIPTION
Because of the missing backtick, the wrong sections of text were being formatted as code.

**Before**
<img width="909" alt="incorrectly_formatted_code" src="https://user-images.githubusercontent.com/6520489/96923327-5b8f2d00-146e-11eb-9d86-9170ebd78e76.png">

**After**
<img width="868" alt="correctly_formatted_code" src="https://user-images.githubusercontent.com/6520489/96923334-5f22b400-146e-11eb-8c64-1bd13d2426b6.png">
