### PR TITLE
Provide module namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+export as namespace testdouble;
+
 //
 // types and interfaces
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Providing a namespace for the module as a whole allows to simplify defining a global instance of `td`. See [this comment](https://github.com/testdouble/testdouble.js/issues/441#issuecomment-851978147).