### PR TITLE
docs: fix link to `testdouble-qunit` plugin

### DIFF
--- a/docs/A-plugins.md
+++ b/docs/A-plugins.md
@@ -23,7 +23,7 @@ Thes plugins developed by ourselves & the community:
 * [testdouble-chai](https://github.com/basecase/testdouble-chai) - Chai assertions
 * [testdouble-jasmine](https://github.com/BrianGenisio/testdouble-jasmine) -
 Jasmine `expect` matchers (by @BrianGenisio)
-* [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit/tree/master/packages/testdouble-qunit) -
+* [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit) -
 QUnit assertion
 
 ## Build Plugins


### PR DESCRIPTION
A while back I simplified the `testdouble-qunit` repo to remove the monorepo structure (as the Ember-specific package that used to also live there became unnecessary). The original documentation link is no longer valid; this updates it to just point directly to the repo itself.