### PR TITLE
Graciously fall back from failed cloneDeep

### DIFF
--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -7,7 +7,14 @@ store.onReset(() => { callHistory = [] })
 
 export default {
   log (testDouble, args, context) {
-    store.for(testDouble).calls.push({ args, context, cloneArgs: _.cloneDeep(args) })
+    let cloneArgs
+    try {
+      cloneArgs = _.cloneDeep(args)
+    } catch (e) {
+      console.error(e)
+      cloneArgs = args
+    }
+    store.for(testDouble).calls.push({ args, context, cloneArgs: cloneArgs })
     return callHistory.push({ testDouble, args, context })
   },
 

--- a/test/unit/function/deep-clone.test.js
+++ b/test/unit/function/deep-clone.test.js
@@ -1,0 +1,24 @@
+let subject, when
+
+module.exports = {
+  beforeEach: () => {
+    subject = require('../../../src/function').default
+    when = require('../../../src/when').default
+  },
+  'recovers from non-deep-cloneable argument': () => {
+    class WeirdClass {}
+    const weirdObject = new WeirdClass()
+    const nothing = undefined
+
+    Object.defineProperty(weirdObject, 'dubiousProp', {
+      enumerable: true,
+      get () {
+        return nothing.dubiousProp
+      }
+    })
+
+    const stubCallback = subject()
+    when(stubCallback(weirdObject)).thenReturn('good result')
+    assert.equal(stubCallback(weirdObject), 'good result')
+  }
+}


### PR DESCRIPTION
In some cases `cloneDeep` can fail, rendering the stub unusable. This PR adds error handling for that case, falling back to using the original `args` object by reference. See discussion in #417.

@searls, please let me know if there's other methods of error handling. I searched for `try/catch` blocks in the source and only found some that were not relevant for this particular use case.