### PR TITLE
Add `thenReturn` to `PromiseStubber` type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ export interface Stubber<D, R = D extends object ? Partial<D> : D> {
 }
 
 export interface PromiseStubber<P, R = P extends object ? Partial<P> : P> {
+  thenReturn<T>(first: Promise<R>, ...args: Array<Promise<R>>): TestDouble<T>;
   thenResolve<T>(first: R, ...args: Array<R>): TestDouble<T>;
   thenDo<T>(f: Function): TestDouble<T>;
   thenReject<T>(e: Error): TestDouble<T>;

--- a/test/safe/typescript-typings.test.ts
+++ b/test/safe/typescript-typings.test.ts
@@ -90,7 +90,7 @@ export = {
     td.when(f(td.matchers.not(false))).thenReject(new Error('rejected'))
 
     const asyncCat = td.instance(AsyncCat)
-    td.when(asyncCat.mewConcurrently()).thenReturn(Promise.resolve("purr"), Promise.reject("hiss!"))
+    td.when(asyncCat.mewConcurrently()).thenReturn(Promise.resolve('purr'), Promise.reject(new Error('hiss!')))
 
     const fakeSum = td.function(sum)
     td.when(fakeSum(1, 2)).thenReturn(3)

--- a/test/safe/typescript-typings.test.ts
+++ b/test/safe/typescript-typings.test.ts
@@ -11,6 +11,12 @@ class Cat {
   }
 }
 
+class AsyncCat {
+  async mewConcurrently (): Promise<string> {
+    return 'meow! meow!'
+  }
+}
+
 function sum (first: number, second: number): number {
   return first + second
 }
@@ -82,6 +88,9 @@ export = {
     })
     td.when(f(td.matchers.not(true))).thenResolve('value1', 'value2')
     td.when(f(td.matchers.not(false))).thenReject(new Error('rejected'))
+
+    const asyncCat = td.instance(AsyncCat)
+    td.when(asyncCat.mewConcurrently()).thenReturn(Promise.resolve("purr"), Promise.reject("hiss!"))
 
     const fakeSum = td.function(sum)
     td.when(fakeSum(1, 2)).thenReturn(3)


### PR DESCRIPTION
This allows you to stub an async function with a sequence of promises that may either resolve or reject.

It will also not allow you to provide non-promise values when stubbing async functions (which is good)

closed #478 