### PR TITLE
Add `types` export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./lib/index.js",
       "import": "./lib/index.mjs"
     },


### PR DESCRIPTION
For a TypeScript project that has `moduleResolution: "nodenext"` set, TypeScript won't respect the existance of an `index.d.ts` when providing type definitions for a module.

Explicitly adding the `"types"` condition in the export definition, as supported by TypeScript 4.7 and later, resolves this problem.

***

I ran into the issue described above while migrating one of my projects to use TypeScript with native ESM. Applying this same fix through a `yarn` patch resolved the issue for my project; hopefully getting this fix upstream will avoid other people bumping into the same thing that I did!