### PR TITLE
fix: replaceEsm typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -304,8 +304,8 @@ export function replace(obj: {}, property: string): TestDouble<any>;
  * @param {*} [defaultExportStub]
  * @returns {Promise<{default?: any, [namedExport: string]: any}>}
  */
-export function replaceEsm(path: string, namedExportStubs?: any, defaultExportStub?: any): Promise<void>;
 export function replaceEsm(path: string): Promise<{default?: any, [namedExport: string]: any}>;
+export function replaceEsm(path: string, namedExportStubs?: any, defaultExportStub?: any): Promise<void>;
 
 /**
  * Swap out real dependencies with fake one. Reference to the property will


### PR DESCRIPTION
Currently, as of the latest version 3.16.7: (#499, CC @asdftd @searls)

```ts
// `subscriptions` is `void`
const subscriptions = await td.replaceEsm(
      '../../subscriptions.js',
);
```

![image](https://user-images.githubusercontent.com/12538019/201755086-0d13fef8-1f1b-4d28-a089-4f19d9365006.png)


Now:

```ts
// `subscriptions` is `{ [namedExport: string]: any; default?: any; }`
const subscriptions = await td.replaceEsm(
      '../../subscriptions.js',
);
```