### PR TITLE
docs: add testdouble-vitest links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ may also want to check out one of these extensions:
 * [testdouble-chai](https://github.com/basecase/testdouble-chai)
 * [testdouble-jasmine](https://github.com/BrianGenisio/testdouble-jasmine)
 * [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit/tree/master/packages/testdouble-qunit)
+* [testdouble-vitest](https://github.com/mcous/testdouble-vitest)
 
 ## Getting started
 

--- a/docs/A-plugins.md
+++ b/docs/A-plugins.md
@@ -17,14 +17,22 @@ your preferred testing framework. However, it may be the case that you'd prefer
 to bridge the `verify()` method of testdouble.js with your preferred assertion
 API for aesthetic or error-handling reasons.
 
-Thes plugins developed by ourselves & the community:
+These plugins developed by ourselves & the community:
 
-* [testdouble-jest](https://github.com/testdouble/testdouble-jest) - module mocking support for Jest users
 * [testdouble-chai](https://github.com/basecase/testdouble-chai) - Chai assertions
 * [testdouble-jasmine](https://github.com/BrianGenisio/testdouble-jasmine) -
 Jasmine `expect` matchers (by @BrianGenisio)
 * [testdouble-qunit](https://github.com/alexlafroscia/testdouble-qunit) -
 QUnit assertion
+
+## Module Replacement Plugins
+
+Some testing frameworks have built-in module replacement systems for injecting
+fakes into your tests. Depending on the framework and your configuration,
+you may need a plugin to use `replace()` / `replaceEsm()` in your tests:
+
+* [testdouble-jest](https://github.com/testdouble/testdouble-jest) - module mocking support for Jest users
+* [testdouble-vitest](https://github.com/mcous/testdouble-vitest) - module module support for Vitest users
 
 ## Build Plugins
 


### PR DESCRIPTION
Following up on https://github.com/testdouble/testdouble.js/issues/484#issuecomment-1323701359, this PR adds a couple links to [testdouble-vitest](https://github.com/mcous/testdouble-vitest) to the docs. This plugin adds `replaceEsm` support when using testdouble.js with [vitest](https://vitest.dev/) by way of vitest's built-in module replacement system, rather than through quibble.

I based it mostly off [testdouble-jest](https://github.com/testdouble/testdouble-jest), with changes to make it fit in with vitest - namely ES Modules and test API access via imports rather than globals.

I shuffled some links around in appendix A since it didn't really feel to me like my plugin (or testdouble-jest for that matter) were "Assertion Plugins", but please free to edit, revert, or whatever as you see fit!