### PR TITLE
fix manual replacement in node-esm examples

### DIFF
--- a/examples/node-esm/test/lib/car-test.js
+++ b/examples/node-esm/test/lib/car-test.js
@@ -7,7 +7,7 @@ mocha.describe('car-test', function () {
     this.gasPedal = (await td.replaceEsm('../../lib/gas-pedal.mjs')).default // <-- a plain ol' function
     this.accelerometer = await td.replaceEsm('../../lib/accelerometer.mjs') // <-- a named export
     this.Brake = (await td.replaceEsm('../../lib/brake.mjs')).default // <-- a constructor function
-    await td.replaceEsm('../../lib/copilot.mjs', undefined, function () { return 'HIGHFIVE' }) // <-- a manual override
+    await td.replaceEsm('../../lib/copilot.mjs', function () { return 'HIGHFIVE' }) // <-- a manual override
     this.subject = await import('../../lib/car.mjs')
   })
 

--- a/examples/node-esm/test/lib/car-test.mjs
+++ b/examples/node-esm/test/lib/car-test.mjs
@@ -7,7 +7,7 @@ mocha.describe('car-test', function () {
     this.gasPedal = (await td.replaceEsm('../../lib/gas-pedal.mjs')).default // <-- a plain ol' function
     this.accelerometer = await td.replaceEsm('../../lib/accelerometer.mjs') // <-- a named export
     this.Brake = (await td.replaceEsm('../../lib/brake.mjs')).default // <-- a constructor function
-    await td.replaceEsm('../../lib/copilot.mjs', undefined, function () { return 'HIGHFIVE' }) // <-- a manual override
+    await td.replaceEsm('../../lib/copilot.mjs', function () { return 'HIGHFIVE' }) // <-- a manual override
     this.subject = await import('../../lib/car.mjs')
   })
 


### PR DESCRIPTION
According to the current [documentation](https://github.com/testdouble/testdouble.js/blob/6535986b76e535edb9db8d1c029ca34335554ec5/docs/7-replacing-dependencies.md), replace signature use only two arguments to do manual replacement when first argument is a string.