### PR TITLE
Replace usage of global with globalThis for better browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ convenience to the shorthand `td`:
 import * as td from 'testdouble'
 
 // CommonJS modules (e.g. Node.js)
-global.td = require('testdouble')
+globalThis.td = require('testdouble')
 
 // Global set in our browser distribution
 window.td
@@ -583,5 +583,3 @@ directory:
 * [td.matchers](/docs/5-stubbing-results.md#loosening-stubbings-with-argument-matchers)
   and [custom matchers](/docs/8-custom-matchers.md#custom-argument-matchers) for
   configuring more advanced stubbings and verifications
-
-

--- a/docs/1-installation.md
+++ b/docs/1-installation.md
@@ -15,7 +15,7 @@ test suite and to name that global something brief. We've been accustomed to
 using `td`, so in a test helper loaded before your tests:
 
 ```
-global.td = require('testdouble')
+globalThis.td = require('testdouble')
 ```
 
 All examples in these documents will assume `testdouble` is available as `td`.
@@ -64,7 +64,7 @@ without any test library at all.
 
 Our browser distribution sets the library on a global variable named `window.td`.
 In Node.js, the library is loaded via `require('testdouble')`, as you might
-expect (though we recommend assigning it to `global.td` in a test helper, for
+expect (though we recommend assigning it to `globalThis.td` in a test helper, for
 terseness sake).
 
 You're welcome to address testdouble.js or any of its functions however you prefer,

--- a/examples/babel/package-lock.json
+++ b/examples/babel/package-lock.json
@@ -49,7 +49,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "../../node_modules/@babel/code-frame": {

--- a/examples/babel/test/helper.js
+++ b/examples/babel/test/helper.js
@@ -1,6 +1,6 @@
 import td from 'testdouble'
 
-global.context = describe
-global.td = td
+globalThis.context = describe
+globalThis.td = td
 
 afterEach(() => td.reset())

--- a/examples/jest-broken/package-lock.json
+++ b/examples/jest-broken/package-lock.json
@@ -50,7 +50,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "../../node_modules/@babel/code-frame": {

--- a/examples/jest/package-lock.json
+++ b/examples/jest/package-lock.json
@@ -50,7 +50,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "../../node_modules/@babel/code-frame": {

--- a/examples/jest/support/helper.js
+++ b/examples/jest/support/helper.js
@@ -1,5 +1,5 @@
-global.td = require('../../..')
-global.expect = require('expect')
+globalThis.td = require('../../..')
+globalThis.expect = require('expect')
 
 require('testdouble-jest')(td, jest)
 

--- a/examples/node-ava/package-lock.json
+++ b/examples/node-ava/package-lock.json
@@ -48,7 +48,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "../../node_modules/@babel/code-frame": {

--- a/examples/node-esm/package-lock.json
+++ b/examples/node-esm/package-lock.json
@@ -48,7 +48,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "../../node_modules/@babel/code-frame": {

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -49,7 +49,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "../../node_modules/@babel/code-frame": {

--- a/examples/node/test/helper.js
+++ b/examples/node/test/helper.js
@@ -1,5 +1,5 @@
-global.td = require('testdouble')
-global.assert = require('core-assert')
+globalThis.td = require('testdouble')
+globalThis.assert = require('core-assert')
 
 module.exports = {
   afterEach: function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -148,6 +148,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 14"
   }
 }

--- a/script/repl
+++ b/script/repl
@@ -4,8 +4,6 @@ require('ts-node/register')
 var repl = require('repl')
 
 console.log('💚  Let\'s play with testdouble.js!  💚')
-global.td = require('../src')
-global.l = require('lodash')
+globalThis.td = require('../src')
+globalThis.l = require('lodash')
 repl.start({prompt: 'td > ', useGlobal: true})
-
-

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ import stringifyAnything from './stringify/anything'
 
 const DEFAULTS = {
   ignoreWarnings: false,
-  promiseConstructor: global.Promise,
+  promiseConstructor: Promise,
   suppressErrors: false
 }
 const DELETED_OPTIONS = ['extendWhenReplacingConstructors']

--- a/src/imitate/overwrite-children/is-fakeable.js
+++ b/src/imitate/overwrite-children/is-fakeable.js
@@ -11,5 +11,5 @@ const isBoxedType = (thing) =>
     Number,
     RegExp,
     String,
-    global.Symbol
+    Symbol
   ]).some(type => thing instanceof type)

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,6 @@
 require('ts-node/register')
-global.assert = require('assert')
-global.ES_SUPPORT = require('./support/es-support')
+globalThis.assert = require('assert')
+globalThis.ES_SUPPORT = require('./support/es-support')
 
 const CallLog = require('../src/value/call-log').default
 const StubbingRegister = require('../src/value/stubbing-register').default

--- a/test/safe/config.test.js
+++ b/test/safe/config.test.js
@@ -2,7 +2,7 @@ module.exports = {
   'sets some ok defaults' () {
     assert.deepEqual(td.config(), {
       ignoreWarnings: false,
-      promiseConstructor: global.Promise,
+      promiseConstructor: Promise,
       suppressErrors: false
     })
   },

--- a/test/safe/constructor.test.js
+++ b/test/safe/constructor.test.js
@@ -97,7 +97,6 @@ module.exports = {
     assert._isEqual(fakeInstance.foo.toString(), '[test double for "#foo"]')
   },
   'edge case: being given a Symbol as function name' () {
-    if (!global.Symbol) return
     const symbolFoo = Symbol('foo')
     FakeConstructor = td.constructor([symbolFoo])
     fakeInstance = new FakeConstructor('biz')

--- a/test/safe/log.test.js
+++ b/test/safe/log.test.js
@@ -43,12 +43,12 @@ module.exports = {
     },
     'when console does not exist' () {
       const ogConsole = console
-      delete global.console
+      delete globalThis.console
 
       subject.warn('lolololol', 'lol')
 
       // No explosions occur
-      global.console = ogConsole
+      globalThis.console = ogConsole
     }
   },
   '.error': {

--- a/test/safe/object.test.js
+++ b/test/safe/object.test.js
@@ -35,7 +35,6 @@ module.exports = {
     assert._isEqual(testDouble.bam.toString(), '[test double for ".bam"]')
   },
   'making a test double based on a Symbol' () {
-    if (!global.Symbol) return
     const symbolFoo = Symbol('foo')
     testDouble = td.object([symbolFoo])
 
@@ -70,7 +69,6 @@ module.exports = {
   },
   'creating a ES Proxy object': {
     'basic use' () {
-      if (!global.Proxy) return
       testDouble = td.object('thing')
       testDouble.magic('sauce')
 
@@ -81,7 +79,6 @@ module.exports = {
       assert._isEqual(testDouble.foo.toString(), '[test double for "thing.foo"]')
     },
     'with custom excludeMethods definitions' () {
-      if (!global.Proxy) return
       testDouble = td.object('Stuff', {
         excludeMethods: ['then', 'fun']
       })
@@ -89,28 +86,16 @@ module.exports = {
       assert._isEqual(testDouble.fun, undefined)
     },
     'unnamed double' () {
-      if (!global.Proxy) return
       testDouble = td.object()
 
       assert._isEqual(testDouble.toString(), '[test double object]')
       assert._isEqual(testDouble.lol.toString(), '[test double for ".lol"]')
     },
     'with Symbol propKey' () {
-      if (!global.Proxy || !global.Symbol) return
       testDouble = td.object('thing')
       assert._isEqual(testDouble[Symbol('foo')].toString(), '[test double for "thing.Symbol(foo)"]')
     },
-    'if Proxy is not defined will print an error message' () {
-      if (global.Proxy) return
-      try {
-        td.object('Woah')
-        assert.fail('Show have errored!')
-      } catch (e) {
-        assert._isEqual(e.message, "Error: testdouble.js - td.object - The current runtime does not have Proxy support, which is what\ntestdouble.js depends on when a string name is passed to `td.object()`.\n\nMore details here:\n  https://github.com/testdouble/testdouble.js/blob/main/docs/4-creating-test-doubles.md#objectobjectname\n\nDid you mean `td.object(['Woah'])`?")
-      }
-    },
     'Allow for deeply nested test double objects' () {
-      if (!global.Proxy) return
       testDouble = td.object()
 
       td.when(testDouble.something.very.deeply.nested()).thenReturn('nay!')
@@ -119,7 +104,6 @@ module.exports = {
       assert._isEqual(testDouble.something.very.deeply.nested.toString(), '[test double for ".something.very.deeply.nested"]')
     },
     'Deeply nested test double objects work also when its property names are repeated' () {
-      if (!global.Proxy) return
       testDouble = td.object()
 
       td.when(testDouble.something()).thenReturn('Original Something')
@@ -129,7 +113,6 @@ module.exports = {
       assert._isEqual(testDouble.different.something(), 'Different Something')
     },
     'Resets all deeply nested test doubles with td.reset' () {
-      if (!global.Proxy) return
       testDouble = td.object()
 
       td.when(testDouble.something()).thenReturn('Original Something')

--- a/test/support/tdify-plugin.js
+++ b/test/support/tdify-plugin.js
@@ -7,10 +7,10 @@ module.exports = {
     test: function (runTest, metadata, cb) {
       if (metadata.ancestorNames[1].indexOf('/test/unit/') !== -1) {
         // Unit test -- `td` is a safe npm release so they can mock!
-        global.td = releaseTd
+        globalThis.td = releaseTd
       } else {
         // Safe test -- `td` is the current working copy so we can assert it!
-        global.td = workingTd
+        globalThis.td = workingTd
       }
       runTest(cb)
     }

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -10,7 +10,7 @@ module.exports = {
 
     assert.deepEqual(result, {
       ignoreWarnings: false,
-      promiseConstructor: global.Promise,
+      promiseConstructor: Promise,
       suppressErrors: false
     })
   },

--- a/test/unit/imitate/create-imitation.test.js
+++ b/test/unit/imitate/create-imitation.test.js
@@ -31,8 +31,6 @@ module.exports = {
     assert.deepEqual(result, 'fake thing')
   },
   'a function with symbols' () {
-    if (!global.Symbol) return
-
     const someFunc = () => {}
     const symFoo = Symbol('foo')
     const symBar = Symbol('bar')
@@ -60,7 +58,6 @@ module.exports = {
     assert.strictEqual(subject(undefined, []), undefined)
   },
   symbols: () => {
-    if (!global.Symbol) return
     assert.strictEqual(subject(Symbol.species, []), Symbol.species)
   },
   'generators do not blow up and just return themselves i guess': () => {

--- a/test/unit/imitate/overwrite-children/is-fakeable.test.js
+++ b/test/unit/imitate/overwrite-children/is-fakeable.test.js
@@ -12,8 +12,6 @@ module.exports = {
     assert.equal(subject(NaN), false)
   },
   'identifies symbols': () => {
-    if (!global.Symbol) return
-
     assert.equal(subject(Symbol.species), false)
   },
   'identifies boxed types and basic value types': () => {


### PR DESCRIPTION
I ran into the same issue as #438 and #471 but the workarounds didn't work. Our stack is TypeScript + esbuild + Karma + mocha (and hopefully testdouble 😀 ). Our library is completely browser-based so we only want to test in real browsers.

These changes are largely the same as #472 but also upgrades the supported node engine as mentioned in https://github.com/testdouble/testdouble.js/issues/471#issuecomment-933481803 . [Node.js Release Schedule](https://github.com/nodejs/release#release-schedule)