### PR TITLE
add missing function alias for ES module

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,6 +13,7 @@ import config2 from './config.js'
 import callback2 from './callback.js'
 import version2 from './version.js'
 export const func = function2.default
+export { func as function }
 export const object = object2.default
 export const constructor = constructor2.default
 export const instance = instance2.default


### PR DESCRIPTION
I'm using testdouble as an ES module (with `import * from 'testdouble'`) and I wasn't able to use the `td.function()`, but only the `td.func()` alias.

It seems the `index.mjs` forgot to export the name `function`.

This patch fix it by adding an alias for `func` in the `index.mjs` file.

I didn't find where to add a test for this, I'll do it if you can give me some insights.