### PR TITLE
make `thenThrow` and `thenReject` accept values of `any` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,9 +56,9 @@ export const matchers: Matchers;
 export interface Stubber<D, R = D extends object ? Partial<D> : D> {
   thenReturn<T>(first: R, ...args: Array<R>): TestDouble<T>;
   thenDo<T>(f: Function): TestDouble<T>;
-  thenThrow<T>(e: Error): TestDouble<T>;
+  thenThrow<T>(e: any): TestDouble<T>;
   thenResolve<T>(first: R, ...args: Array<R>): TestDouble<T>;
-  thenReject<T>(e: Error): TestDouble<T>;
+  thenReject<T>(e: any): TestDouble<T>;
   thenCallback<T>(error: any, data: any): TestDouble<T>;
 }
 
@@ -66,7 +66,7 @@ export interface PromiseStubber<P, R = P extends object ? Partial<P> : P> {
   thenReturn<T>(first: Promise<R>, ...args: Array<Promise<R>>): TestDouble<T>;
   thenResolve<T>(first: R, ...args: Array<R>): TestDouble<T>;
   thenDo<T>(f: Function): TestDouble<T>;
-  thenReject<T>(e: Error): TestDouble<T>;
+  thenReject<T>(e: any): TestDouble<T>;
 }
 
 export interface TestdoubleConfig {


### PR DESCRIPTION
Hello there,

[In TypeScript](https://github.com/microsoft/TypeScript/blob/f64f40d20511d2d2a9eb4fcc1ad6750977be2d40/src/lib/es2015.promise.d.ts#L42), `Promise.reject` accepts a reason of type `any`. 

Since `thenReject` is a short-hand for `thenReturn(Promise.reject)`, the proposal here is to make `thenReject` accept a parameter of type `any`. The same applies for `throw` vs. `thenThrow`.

Ciao!