### PR TITLE
feat(types): add "version" export to type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -335,3 +335,5 @@ export function when<D>(f: D, config?: WhenConfig): Stubber<D>;
  * @returns {Stubber}
  */
 export function verify(a: any, check?: VerificationConfig): void;
+
+export const version: string;


### PR DESCRIPTION
I noticed this was missing in the type definitions.